### PR TITLE
Improve backward compatibility of Gradle versions.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/AsakusafwSparkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/AsakusafwSparkPlugin.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 
 import com.asakusafw.spark.gradle.plugins.internal.AsakusaSparkCompilerPlugin
 import com.asakusafw.spark.gradle.plugins.internal.AsakusaSparkOrganizerPlugin
+import com.asakusafw.spark.gradle.plugins.internal.PluginUtils
 
 /**
  * A Gradle plug-in for Asakusa projects for Spark runtime.
@@ -28,10 +29,10 @@ class AsakusafwSparkPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        project.plugins.withId('asakusafw') {
+        PluginUtils.afterPluginEnabled(project, 'asakusafw') {
             project.apply plugin: AsakusaSparkCompilerPlugin
         }
-        project.plugins.withId('asakusafw-organizer') {
+        PluginUtils.afterPluginEnabled(project, 'asakusafw-organizer') {
             project.apply plugin: AsakusaSparkOrganizerPlugin
         }
     }

--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkCompilerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkCompilerPlugin.groovy
@@ -79,7 +79,7 @@ class AsakusaSparkCompilerPlugin implements Plugin<Project> {
                 description 'Asakusa DSL Compiler Launcher for Spark environment'
             }
         }
-        project.afterEvaluate {
+        PluginUtils.afterEvaluate(project) {
             AsakusaSparkBaseExtension base = AsakusaSparkBasePlugin.get(project)
             AsakusafwPluginConvention asakusa = project.asakusafw
             project.configurations {
@@ -162,7 +162,7 @@ class AsakusaSparkCompilerPlugin implements Plugin<Project> {
                 failOnError = { spark.failOnError }
             }
         }
-        project.afterEvaluate {
+        PluginUtils.afterEvaluate(project) {
             AsakusaCompileTask task = project.tasks.sparkCompileBatchapps
             Map<String, String> map = [:]
             map.putAll(ResolutionUtils.resolveToStringMap(spark.compilerProperties))

--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkOrganizer.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkOrganizer.groovy
@@ -53,7 +53,7 @@ class AsakusaSparkOrganizer extends AbstractOrganizer {
     }
 
     private void configureDependencies() {
-        project.afterEvaluate {
+        PluginUtils.afterEvaluate(project) {
             AsakusaSparkBaseExtension base = AsakusaSparkBasePlugin.get(project)
             createDependencies('asakusafw', [
                 SparkDist : "com.asakusafw.spark:asakusa-spark-assembly:${base.sparkProjectVersion}:dist@jar",
@@ -86,7 +86,7 @@ class AsakusaSparkOrganizer extends AbstractOrganizer {
     }
 
     private void enableTasks() {
-        project.afterEvaluate {
+        PluginUtils.afterEvaluate(project) {
             AsakusafwOrganizerSparkExtension spark = profile.spark
             if (spark.isEnabled()) {
                 project.logger.info 'Enabling Asakusa on Spark'

--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/PluginUtils.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/PluginUtils.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2011-2015 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.spark.gradle.plugins.internal
+
+import org.gradle.api.Project
+import org.gradle.api.ProjectState;
+import org.gradle.util.GradleVersion
+
+/**
+ * Basic utilities for Gradle plug-ins.
+ * FIXME merge to main
+ */
+final class PluginUtils {
+
+    /**
+     * Executes a closure after the project was evaluated only if evaluation was not failed.
+     * @param project the target project
+     * @param closure the closure
+     */
+    static void afterEvaluate(Project project, Closure<?> closure) {
+        project.afterEvaluate { Project p, ProjectState state ->
+            if (state.failure != null) {
+                return
+            }
+            closure.call(project)
+        }
+    }
+
+    /**
+     * Compares the target Gradle version with the current Gradle version.
+     * @param version the target Gradle version
+     * @return {@code =0} - same, {@code >0} - the current version is newer, {@code <0} - the current version is older
+     */
+    static int compareGradleVersion(String version) {
+        GradleVersion current = GradleVersion.current()
+        GradleVersion target = GradleVersion.version(version)
+        return current.compareTo(target)
+    }
+
+    /**
+     * Calls a closure after the target plug-in is enabled.
+     * @param project the current project
+     * @param pluginType the target plug-in class
+     * @param closure the closure
+     */
+    static void afterPluginEnabled(Project project, Class<?> pluginType, Closure<?> closure) {
+        project.plugins.withType(pluginType) {
+            closure.call()
+        }
+    }
+
+    /**
+     * Calls a closure after the target plug-in is enabled.
+     * @param project the current project
+     * @param pluginType the target plug-in class
+     * @param closure the closure
+     */
+    static void afterPluginEnabled(Project project, String pluginId, Closure<?> closure) {
+        if (compareGradleVersion('2.0') >= 0) {
+            project.plugins.withId(pluginId) {
+                closure.call()
+            }
+        } else {
+            project.plugins.matching({ it == project.plugins.findPlugin(pluginId) }).all {
+                closure.call()
+            }
+        }
+    }
+
+    private PluginUtils() {
+    }
+}


### PR DESCRIPTION
This improvement enables that the `asakusa-spark` plug-in accepts Gradle `1.12` (currently `>= 2.0` only).
