### PR TITLE
Exclude asm:asm.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<name>Asakusa DSL Compiler for Spark Project Root</name>
@@ -24,12 +25,12 @@
 		<url>http://asakusafw.com</url>
 	</organization>
 
-  <scm>
-    <connection>scm:git:git@github.com:asakusafw/asakusafw-spark.git</connection>
-    <developerConnection>scm:git:git@github.com:asakusafw/asakusafw-spark.git</developerConnection>
-    <url>https://github.com/asakusafw/asakusafw-spark</url>
-    <tag>HEAD</tag>
-  </scm>
+	<scm>
+		<connection>scm:git:git@github.com:asakusafw/asakusafw-spark.git</connection>
+		<developerConnection>scm:git:git@github.com:asakusafw/asakusafw-spark.git</developerConnection>
+		<url>https://github.com/asakusafw/asakusafw-spark</url>
+		<tag>HEAD</tag>
+	</scm>
 
 	<properties>
 		<artifact.name>${project.artifactId}</artifact.name>
@@ -498,6 +499,10 @@ encoding/<project>=UTF-8
 					<exclusion>
 						<groupId>commons-logging</groupId>
 						<artifactId>commons-logging</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>asm</groupId>
+						<artifactId>asm</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Dependency on the old version ASM might cause unexpected errors.
