### PR TITLE
Change default log level in Maven test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,10 @@
               </property>
               <property>
                 <name>org.slf4j.simpleLogger.defaultLogLevel</name>
+                <value>info</value>
+              </property>
+              <property>
+                <name>org.slf4j.simpleLogger.log.com.asakusafw</name>
                 <value>debug</value>
               </property>
             </systemProperties>


### PR DESCRIPTION
## Summary

This PR changes default log leven in Maven test phase.
## Background, Problem or Goal of the patch

Currently console logs on maven test phase have over 300MB, includes redundant debug logs via spark or jetty.
## Design of the fix, or a new feature

This PR changes default log level to info, and specifies `com.asakusafw` package log level to debug.
## Related Issue, Pull Request or Code
## Wanted reviewer
