### PR TITLE
Modify ClassServer to use RPC transmission instead of HttpServer.

### DIFF
--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/SparkWithClassServerForAll.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/SparkWithClassServerForAll.scala
@@ -33,16 +33,14 @@ trait SparkWithClassServerForAll extends TempDirForAll with SparkForAll { self: 
   }
 
   override def configure(conf: SparkConf): SparkConf = {
-    classServer = new ClassServer(createTempDirectoryForAll("classserver-"), cl, conf)
-    val uri = classServer.start()
+    classServer = new ClassServer(createTempDirectoryForAll("classserver-"), cl)
     Thread.currentThread().setContextClassLoader(classServer.classLoader)
 
-    conf.set("spark.repl.class.uri", uri)
+    conf.set("spark.repl.class.outputDir", classServer.root.toFile.getAbsolutePath)
   }
 
   override def afterStopSparkContext(): Unit = {
     try {
-      classServer.stop()
       classServer = null
     } finally {
       Thread.currentThread().setContextClassLoader(cl)

--- a/runtime/src/main/scala/org/apache/spark/backdoor/package.scala
+++ b/runtime/src/main/scala/org/apache/spark/backdoor/package.scala
@@ -19,9 +19,6 @@ import org.apache.spark.util.CallSite
 
 package object backdoor {
 
-  type HttpServer = org.apache.spark.HttpServer
-  type SecurityManager = org.apache.spark.SecurityManager
-
   implicit class SparkContextBackdoor(val sc: SparkContext) extends AnyVal {
 
     def clean[F <: AnyRef](f: F, checkSerializable: Boolean = true): F = {


### PR DESCRIPTION
## Summary

Modify `ClassServer` to use RPC transmission of Spark instead of `HttpServer`.
## Background, Problem or Goal of the patch

`HttpServer` will be removed soon and Spark itself does not use it but RPC transmission.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
