### PR TITLE
Modify Extract and NewHadoopOutput to coalesce before partition to un…

### DIFF
--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Extract.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Extract.scala
@@ -52,8 +52,8 @@ abstract class Extract[T](
           val numPartitions =
             Partitioner.defaultPartitioner(prevs.head, prevs.tail: _*).numPartitions
           val coalesced = prevs.map {
-            case prev if prev.partitions.size == numPartitions => prev
-            case prev => prev.coalesce(numPartitions, shuffle = false)
+            case prev: RDD[(_, T)] if prev.partitions.size == numPartitions => prev
+            case prev: RDD[(_, T)] => prev.coalesce(numPartitions, shuffle = false)
           }
           val (zipping, unioning) = coalesced.partition(_.partitions.size == numPartitions)
           val zipped = if (zipping.nonEmpty) {

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/NewHadoopOutput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/NewHadoopOutput.scala
@@ -53,8 +53,8 @@ abstract class NewHadoopOutput(
         val numPartitions =
           Partitioner.defaultPartitioner(prevs.head, prevs.tail: _*).numPartitions
         val coalesced = prevs.map {
-          case prev if prev.partitions.size == numPartitions => prev
-          case prev => prev.coalesce(numPartitions, shuffle = false)
+          case prev: RDD[(_, _)] if prev.partitions.size == numPartitions => prev
+          case prev: RDD[(_, _)] => prev.coalesce(numPartitions, shuffle = false)
         }
         val (zipping, unioning) = coalesced.partition(_.partitions.size == numPartitions)
         val zipped = if (zipping.nonEmpty) {

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/NewHadoopOutput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/NewHadoopOutput.scala
@@ -50,16 +50,15 @@ abstract class NewHadoopOutput(
       rdds.head
     } else {
       Future.sequence(rdds).map { prevs =>
-        val part = Partitioner.defaultPartitioner(prevs.head, prevs.tail: _*)
-        val (unioning, coalescing) = prevs.partition(_.partitions.size < part.numPartitions)
-        val coalesced = if (coalescing.nonEmpty) {
-          (coalescing.map { prev =>
-            if (prev.partitions.size == part.numPartitions) {
-              prev
-            } else {
-              prev.coalesce(part.numPartitions, shuffle = false)
-            }
-          }).reduceLeft {
+        val numPartitions =
+          Partitioner.defaultPartitioner(prevs.head, prevs.tail: _*).numPartitions
+        val coalesced = prevs.map {
+          case prev if prev.partitions.size == numPartitions => prev
+          case prev => prev.coalesce(numPartitions, shuffle = false)
+        }
+        val (zipping, unioning) = coalesced.partition(_.partitions.size == numPartitions)
+        val zipped = if (zipping.nonEmpty) {
+          zipping.reduceLeft {
             (left, right) =>
               left.zipPartitions(right, preservesPartitioning = false)(_ ++ _)
           }
@@ -67,9 +66,9 @@ abstract class NewHadoopOutput(
           sc.emptyRDD[(_, _)]
         }
         if (unioning.isEmpty) {
-          coalesced
+          zipped
         } else {
-          sc.union(coalesced +: unioning)
+          sc.union(zipped, unioning: _*)
         }
       }
     })


### PR DESCRIPTION
…ioning and zipping.
## Summary

Modified `Extract` and `NewHadoopOutput` to coalesce before partition to unioning and zipping.
## Background, Problem or Goal of the patch

`zipPartitions` throws the following Exception because `RDD.coalesce()` sometimes makes `RDD` with less partitions than we expected:

```
java.lang.IllegalArgumentException: Can't zip RDDs with unequal numbers of partitions
```
## Design of the fix, or a new feature

Modify them to do `coalesce` before partition `RDD`s to `union` or `zipPartition` to ensure the number of partitions to zip are the same.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
