### PR TITLE
Add Hive schema generator extension to compiler.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPlugin.groovy
@@ -132,6 +132,7 @@ class AsakusaSparkSdkPlugin implements Plugin<Project> {
                 asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.langVersion}"
                 asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.langVersion}"
                 asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-directio:${base.langVersion}"
+                asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.langVersion}"
                 asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-windgate:${base.langVersion}"
                 asakusaSparkCommon "com.asakusafw.iterative:asakusa-compiler-extension-iterative:${base.langVersion}"
                 asakusaSparkCommon "com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-compiler-iterative:${base.featureVersion}"


### PR DESCRIPTION
## Summary

This commit enables to generate Hive schema information on compiling batch applications.
## Background, Problem or Goal of the patch

see asakusafw/asakusafw-compiler#60.
## Design of the fix, or a new feature

Note that, this feature is always active even if target batch application project does not have hive related dependencies. In such case, the compiler will generate empty files for schema info.
## Related Issue, Pull Request or Code
- asakusafw/asakusafw-compiler#60
- asakusafw/asakusafw-compiler#61
## Wanted reviewer

@akirakw
