### PR TITLE
Modify Extract and NewHadoopOutput to use zipPartitions and union ins…

### DIFF
--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/NewHadoopOutput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/NewHadoopOutput.scala
@@ -50,28 +50,15 @@ abstract class NewHadoopOutput(
       rdds.head
     } else {
       Future.sequence(rdds).map { prevs =>
-        val numPartitions =
-          Partitioner.defaultPartitioner(prevs.head, prevs.tail: _*).numPartitions
-        val coalesced = prevs.map { prev =>
-          if (prev.partitions.size == numPartitions) {
-            prev
-          } else {
-            prev.coalesce(numPartitions, shuffle = false)
-          }
-        }
-        val (zipping, unioning) = coalesced.partition(_.partitions.size == numPartitions)
-        val zipped = if (zipping.nonEmpty) {
-          zipping.reduceLeft {
-            (left, right) =>
-              left.zipPartitions(right, preservesPartitioning = false)(_ ++ _)
-          }
+        val zipped =
+          prevs.groupBy(_.partitions.length).map {
+            case (_, rdds) =>
+              rdds.reduce(_.zipPartitions(_, preservesPartitioning = false)(_ ++ _))
+          }.toSeq
+        if (zipped.size == 1) {
+          zipped.head
         } else {
-          sc.emptyRDD[(_, _)]
-        }
-        if (unioning.isEmpty) {
-          zipped
-        } else {
-          sc.union(zipped, unioning: _*)
+          sc.union(zipped)
         }
       }
     })


### PR DESCRIPTION
…tead of coalesce.
## Summary

This is a follow up of #181.
## Background, Problem or Goal of the patch

Using `zipPartitions` to RDDs grouped by the partition size and then `union` would be better way.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
