### PR TITLE
Remove unused findbugs exclusion file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,6 @@ encoding/<project>=UTF-8
           <configuration>
             <xmlOutput>true</xmlOutput>
             <findbugsXmlOutput>true</findbugsXmlOutput>
-            <excludeFilterFile>com/asakusafw/fb_exclude.xml</excludeFilterFile>
             <sourceEncoding>UTF-8</sourceEncoding>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>


### PR DESCRIPTION
## Summary

This commit removes unused findbugs exclusion file in pom.xml.
## Background, Problem or Goal of the patch

same as asakusafw/asakusafw-compiler#65.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
