### PR TITLE
Bump Spark version to 1.6.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <scala.compat.version>2.10</scala.compat.version>
     <scala.version>${scala.compat.version}.6</scala.version>
-    <spark.version>1.6.1</spark.version>
+    <spark.version>1.6.2</spark.version>
     <jetty.version>8.1.14.v20131031</jetty.version>
     <hadoop.version>2.7.2</hadoop.version>
     <asm.version>5.0.3</asm.version>


### PR DESCRIPTION
## Summary

Bump Spark version to 1.6.2.
## Background, Problem or Goal of the patch

Spark 1.6.2 was released.
## Design of the fix, or a new feature

N/A
## Related Issue, Pull Request or Code

N/A
## Wanted reviewer

N/A
