### PR TITLE
Fix ComputeByParameter not to use WeakHashMap.

### DIFF
--- a/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/ComputeByParameter.scala
+++ b/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/ComputeByParameter.scala
@@ -32,7 +32,7 @@ trait ComputeByParameter {
 
   @transient
   private val generatedRDDs: mutable.Map[Seq[String], Map[BranchKey, Future[RDD[_]]]] =
-    mutable.WeakHashMap.empty
+    mutable.Map.empty
 
   override def getOrCompute(
     rc: RoundContext)(implicit ec: ExecutionContext): Map[BranchKey, Future[RDD[_]]] = {


### PR DESCRIPTION
## Summary

Fix `ComputeByParameter` not to use `WeakHashMap`.
## Background, Problem or Goal of the patch

`ComputeByParameter` should not use `WeakHashMap` for store generated RDDs.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

N/A.
