### PR TITLE
Bump up Java version to 1.8.

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -54,7 +54,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>

--- a/extensions/iterativebatch/compiler/core/pom.xml
+++ b/extensions/iterativebatch/compiler/core/pom.xml
@@ -52,7 +52,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>

--- a/extensions/iterativebatch/compiler/iterative/pom.xml
+++ b/extensions/iterativebatch/compiler/iterative/pom.xml
@@ -52,7 +52,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>

--- a/extensions/iterativebatch/runtime/core/pom.xml
+++ b/extensions/iterativebatch/runtime/core/pom.xml
@@ -54,7 +54,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>

--- a/extensions/iterativebatch/runtime/iterative/pom.xml
+++ b/extensions/iterativebatch/runtime/iterative/pom.xml
@@ -52,7 +52,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <asakusafw-sdk.version>0.9.0-SNAPSHOT</asakusafw-sdk.version>
     <asakusafw-lang.version>0.4.0-SNAPSHOT</asakusafw-lang.version>
 
+    <java.version>1.8</java.version>
     <scala.compat.version>2.10</scala.compat.version>
     <scala.version>${scala.compat.version}.6</scala.version>
     <spark.version>1.6.2</spark.version>
@@ -86,8 +87,8 @@
           <version>3.2</version>
           <configuration>
             <fork>true</fork>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
             <encoding>UTF-8</encoding>
             <proc>none</proc>
           </configuration>
@@ -183,12 +184,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-eclipse-plugin</artifactId>
-          <version>2.9</version>
+          <version>2.10</version>
           <configuration>
             <downloadSources>true</downloadSources>
             <downloadJavadocs>false</downloadJavadocs>
             <classpathContainers>
-              <classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7</classpathContainer>
+              <classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-${java.version}</classpathContainer>
             </classpathContainers>
             <additionalConfig>
               <file>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -54,7 +54,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>

--- a/tools/asm/pom.xml
+++ b/tools/asm/pom.xml
@@ -54,7 +54,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>

--- a/tools/asm4s/pom.xml
+++ b/tools/asm4s/pom.xml
@@ -54,7 +54,7 @@ eclipse.preferences.version=1
 scala.compiler.additionalParams=\ -Xsource\:2.10 -Ymacro-expand\:none
 scala.compiler.installation=2.10
 scala.compiler.useProjectSettings=true
-target=jvm-1.7
+target=jvm-${java.version}
 ]]>
               </content>
             </file>


### PR DESCRIPTION
## Summary

This PR bumps up Java version to `1.8`.
## Background, Problem or Goal of the patch

N/A.
## Design of the fix, or a new feature

Note that the Java version of building Gradle plugin is still `1.7`.
This is for backward compatibility of `asakusaUpgrade` task.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@ueshin 
