### PR TITLE
Modify to use `Job.getInstance()` to prepare for dropping hadoop1 dependency.

### DIFF
--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/SparkClientCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/SparkClientCompilerSpec.scala
@@ -28,6 +28,7 @@ import scala.reflect.{ classTag, ClassTag }
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.{ SparkConf, SparkContext }
 import org.apache.spark.rdd.RDD
@@ -47,7 +48,6 @@ import com.asakusafw.lang.compiler.model.graph._
 import com.asakusafw.lang.compiler.model.info.ExternalInputInfo
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning._
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.core.Result
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.StageConstants
@@ -88,7 +88,7 @@ class SparkClientCompilerSpec extends FlatSpec with LoadClassSugar with TempDirF
     }
 
     def prepareData[T: ClassTag](name: String, path: File)(rdd: RDD[T])(implicit sc: SparkContext): Unit = {
-      val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+      val job = MRJob.getInstance(sc.hadoopConfiguration)
       job.setOutputKeyClass(classOf[NullWritable])
       job.setOutputValueClass(classTag[T].runtimeClass)
       job.setOutputFormatClass(classOf[TemporaryOutputFormat[T]])
@@ -97,7 +97,7 @@ class SparkClientCompilerSpec extends FlatSpec with LoadClassSugar with TempDirF
     }
 
     def readResult[T: ClassTag](name: String, path: File)(implicit sc: SparkContext): RDD[T] = {
-      val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+      val job = MRJob.getInstance(sc.hadoopConfiguration)
       TemporaryInputFormat.setInputPaths(job, Seq(new Path(path.getPath, s"${name}/-/part-*")))
       sc.newAPIHadoopRDD(
         job.getConfiguration,

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/InputClassBuilderSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/InputClassBuilderSpec.scala
@@ -30,6 +30,7 @@ import scala.concurrent.duration.Duration
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.SparkContext
 
@@ -40,7 +41,6 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ ExternalInput, MarkerOperator }
 import com.asakusafw.lang.compiler.model.info.ExternalInputInfo
 import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
@@ -62,7 +62,7 @@ abstract class InputClassBuilderSpec extends FlatSpec with ClassServerForAll wit
   import InputClassBuilderSpec._
 
   def prepareInput(path: String, ints: Seq[Int]): Unit = {
-    val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+    val job = MRJob.getInstance(sc.hadoopConfiguration)
     job.setOutputKeyClass(classOf[NullWritable])
     job.setOutputValueClass(classOf[Foo])
     job.setOutputFormatClass(classOf[TemporaryOutputFormat[Foo]])
@@ -278,7 +278,7 @@ class DirectInputClassBuilderSpec
   }
 
   private def mkExtraConfigurations(path: String): Map[String, String] = {
-    val job = JobCompatibility.newJob(new Configuration(false))
+    val job = MRJob.getInstance(new Configuration(false))
     FileInputFormat.setInputPaths(job, new Path(path + "/part-*"))
     Map(FileInputFormat.INPUT_DIR -> job.getConfiguration.get(FileInputFormat.INPUT_DIR))
   }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/OutputClassBuilderSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/OutputClassBuilderSpec.scala
@@ -29,6 +29,7 @@ import scala.concurrent.duration.Duration
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.SparkContext
 
@@ -38,7 +39,6 @@ import com.asakusafw.lang.compiler.api.testing.MockJobflowProcessorContext
 import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ ExternalOutput, MarkerOperator }
 import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.value.IntOption
@@ -60,7 +60,7 @@ abstract class OutputClassBuilderSpec extends FlatSpec with ClassServerForAll wi
   import OutputClassBuilderSpec._
 
   def readResult(path: String, rc: RoundContext): Seq[Int] = {
-    val job = JobCompatibility.newJob(rc.hadoopConf.value)
+    val job = MRJob.getInstance(rc.hadoopConf.value)
 
     val stageInfo = StageInfo.deserialize(job.getConfiguration.get(StageInfo.KEY_NAME))
     FileInputFormat.setInputPaths(job, new Path(stageInfo.resolveUserVariables(path + "/-/part-*")))

--- a/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/IterativeBatchExecutorCompilerSpec.scala
+++ b/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/IterativeBatchExecutorCompilerSpec.scala
@@ -29,6 +29,7 @@ import scala.reflect.{ classTag, ClassTag }
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.{ SparkConf, SparkContext }
 import org.apache.spark.rdd.RDD
@@ -47,7 +48,6 @@ import com.asakusafw.lang.compiler.model.info.ExternalInputInfo
 import com.asakusafw.lang.compiler.model.iterative.IterativeExtension
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning._
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.core.Result
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
@@ -100,7 +100,7 @@ class IterativeBatchExecutorCompilerSpecBase(threshold: Option[Int], parallelism
   }
 
   def prepareData[T: ClassTag](name: String, path: File)(rdd: RDD[T])(implicit sc: SparkContext): Unit = {
-    val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+    val job = MRJob.getInstance(sc.hadoopConfiguration)
     job.setOutputKeyClass(classOf[NullWritable])
     job.setOutputValueClass(classTag[T].runtimeClass)
     job.setOutputFormatClass(classOf[TemporaryOutputFormat[T]])
@@ -111,7 +111,7 @@ class IterativeBatchExecutorCompilerSpecBase(threshold: Option[Int], parallelism
   }
 
   def readResult[T: ClassTag](name: String, round: Int, path: File)(implicit sc: SparkContext): RDD[T] = {
-    val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+    val job = MRJob.getInstance(sc.hadoopConfiguration)
     TemporaryInputFormat.setInputPaths(
       job,
       Seq(new Path(path.getPath, s"${name}/round_${round}/part-*")))

--- a/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/InputClassBuilderSpec.scala
+++ b/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/InputClassBuilderSpec.scala
@@ -30,6 +30,7 @@ import scala.concurrent.duration.Duration
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.SparkContext
 
@@ -42,7 +43,6 @@ import com.asakusafw.lang.compiler.model.graph.{ ExternalInput, MarkerOperator }
 import com.asakusafw.lang.compiler.model.info.ExternalInputInfo
 import com.asakusafw.lang.compiler.model.iterative.IterativeExtension
 import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.StageConstants
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
@@ -69,7 +69,7 @@ abstract class InputClassBuilderSpec extends FlatSpec with ClassServerForAll wit
   import InputClassBuilderSpec._
 
   def prepareRound(parent: String, ints: Seq[Int], round: Int): Unit = {
-    val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+    val job = MRJob.getInstance(sc.hadoopConfiguration)
     job.setOutputKeyClass(classOf[NullWritable])
     job.setOutputValueClass(classOf[Foo])
     job.setOutputFormatClass(classOf[TemporaryOutputFormat[Foo]])
@@ -337,7 +337,7 @@ class DirectInputClassBuilderSpec
   }
 
   private def mkExtraConfigurations(path: String): Map[String, String] = {
-    val job = JobCompatibility.newJob(new Configuration(false))
+    val job = MRJob.getInstance(new Configuration(false))
     FileInputFormat.setInputPaths(job, new Path(path + "/part-*"))
     Map(FileInputFormat.INPUT_DIR -> job.getConfiguration.get(FileInputFormat.INPUT_DIR))
   }

--- a/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/OutputClassBuilderSpec.scala
+++ b/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/OutputClassBuilderSpec.scala
@@ -29,6 +29,7 @@ import scala.concurrent.duration.Duration
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.SparkContext
 
@@ -38,7 +39,6 @@ import com.asakusafw.lang.compiler.api.testing.MockJobflowProcessorContext
 import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ ExternalOutput, MarkerOperator }
 import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.value.IntOption
@@ -64,7 +64,7 @@ abstract class OutputClassBuilderSpec extends FlatSpec with ClassServerForAll wi
   import OutputClassBuilderSpec._
 
   def readResult(path: String, rc: RoundContext): Seq[Int] = {
-    val job = JobCompatibility.newJob(rc.hadoopConf.value)
+    val job = MRJob.getInstance(rc.hadoopConf.value)
 
     val stageInfo = StageInfo.deserialize(job.getConfiguration.get(StageInfo.KEY_NAME))
     FileInputFormat.setInputPaths(

--- a/extensions/iterativebatch/compiler/iterative/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/iterative/IterativeBatchExtensionCompilerSpec.scala
+++ b/extensions/iterativebatch/compiler/iterative/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/iterative/IterativeBatchExtensionCompilerSpec.scala
@@ -28,6 +28,7 @@ import scala.reflect.{ classTag, ClassTag }
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.spark.{ SparkConf, SparkContext }
 import org.apache.spark.rdd.RDD
 
@@ -46,7 +47,6 @@ import com.asakusafw.lang.compiler.model.info.ExternalInputInfo
 import com.asakusafw.lang.compiler.model.iterative.IterativeExtension
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning._
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
@@ -76,7 +76,7 @@ class IterativeBatchExtensionCompilerSpec extends FlatSpec with LoadClassSugar w
   }
 
   def prepareData[T: ClassTag](name: String, path: File)(rdd: RDD[T])(implicit sc: SparkContext): Unit = {
-    val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+    val job = MRJob.getInstance(sc.hadoopConfiguration)
     job.setOutputKeyClass(classOf[NullWritable])
     job.setOutputValueClass(classTag[T].runtimeClass)
     job.setOutputFormatClass(classOf[TemporaryOutputFormat[T]])
@@ -87,7 +87,7 @@ class IterativeBatchExtensionCompilerSpec extends FlatSpec with LoadClassSugar w
   }
 
   def readResult[T: ClassTag](name: String, round: Int, path: File)(implicit sc: SparkContext): RDD[T] = {
-    val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+    val job = MRJob.getInstance(sc.hadoopConfiguration)
     TemporaryInputFormat.setInputPaths(
       job,
       Seq(new Path(path.getPath, s"${name}/round_${round}/part-*")))

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/DirectInput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/DirectInput.scala
@@ -21,7 +21,6 @@ import scala.reflect.ClassTag
 import org.apache.hadoop.mapreduce.{ InputFormat, Job => MRJob }
 import org.apache.spark.SparkContext
 
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.spark.runtime.rdd.ShuffleKey
 
 abstract class DirectInput[IF <: InputFormat[K, V]: ClassTag, K: ClassTag, V: ClassTag](
@@ -32,7 +31,7 @@ abstract class DirectInput[IF <: InputFormat[K, V]: ClassTag, K: ClassTag, V: Cl
   def extraConfigurations: Map[String, String]
 
   override def newJob(rc: RoundContext): MRJob = {
-    val job = JobCompatibility.newJob(rc.hadoopConf.value)
+    val job = MRJob.getInstance(rc.hadoopConf.value)
     extraConfigurations.foreach {
       case (k, v) => job.getConfiguration.set(k, v)
     }

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryInput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryInput.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.SparkContext
 
 import com.asakusafw.bridge.stage.StageInfo
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 
 abstract class TemporaryInput[V: ClassTag](
@@ -36,7 +35,7 @@ abstract class TemporaryInput[V: ClassTag](
   def paths: Set[String]
 
   override def newJob(rc: RoundContext): MRJob = {
-    val job = JobCompatibility.newJob(rc.hadoopConf.value)
+    val job = MRJob.getInstance(rc.hadoopConf.value)
     val stageInfo = StageInfo.deserialize(job.getConfiguration.get(StageInfo.KEY_NAME))
     FileInputFormat.setInputPaths(job, paths.map { path =>
       new Path(stageInfo.resolveUserVariables(path))

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryOutput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryOutput.scala
@@ -24,7 +24,6 @@ import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.spark.SparkContext
 
 import com.asakusafw.bridge.stage.StageInfo
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.spark.runtime.rdd.BranchKey
 
@@ -36,7 +35,7 @@ abstract class TemporaryOutput[T: ClassTag](
   def path: String
 
   override def newJob(rc: RoundContext): MRJob = {
-    val job = JobCompatibility.newJob(rc.hadoopConf.value)
+    val job = MRJob.getInstance(rc.hadoopConf.value)
     job.setOutputKeyClass(classOf[NullWritable])
     job.setOutputValueClass(classTag[T].runtimeClass.asInstanceOf[Class[T]])
     job.setOutputFormatClass(classOf[TemporaryOutputFormat[T]])

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/InputSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/InputSpec.scala
@@ -29,11 +29,11 @@ import scala.concurrent.duration.Duration
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.{ Partitioner, SparkConf, SparkContext }
 import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
@@ -49,7 +49,7 @@ abstract class InputSpec extends FlatSpec with SparkForAll {
   import InputSpec._
 
   def prepareRound(path: String, ints: Seq[Int]): Unit = {
-    val job = JobCompatibility.newJob(sc.hadoopConfiguration)
+    val job = MRJob.getInstance(sc.hadoopConfiguration)
     job.setOutputKeyClass(classOf[NullWritable])
     job.setOutputValueClass(classOf[Foo])
     job.setOutputFormatClass(classOf[TemporaryOutputFormat[Foo]])
@@ -191,7 +191,7 @@ class DirectInputSpec extends InputSpec with RoundContextSugar with TempDirForEa
   }
 
   private def mkExtraConfigurations(basePaths: Set[String]): Map[String, String] = {
-    val job = JobCompatibility.newJob(new Configuration(false))
+    val job = MRJob.getInstance(new Configuration(false))
     FileInputFormat.setInputPaths(job, basePaths.map(path => new Path(path + "/part-*")).toSeq: _*)
     Map(FileInputFormat.INPUT_DIR -> job.getConfiguration.get(FileInputFormat.INPUT_DIR))
   }

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/OutputSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/OutputSpec.scala
@@ -29,11 +29,11 @@ import scala.concurrent.duration.Duration
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
+import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.{ SparkConf, SparkContext }
 
 import com.asakusafw.bridge.stage.StageInfo
-import com.asakusafw.runtime.compatibility.JobCompatibility
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.StageConstants.EXPR_EXECUTION_ID
 import com.asakusafw.runtime.stage.input.TemporaryInputFormat
@@ -47,7 +47,7 @@ abstract class OutputSpec extends FlatSpec with SparkForAll {
   import OutputSpec._
 
   def readResult(path: String, rc: RoundContext): Seq[Int] = {
-    val job = JobCompatibility.newJob(rc.hadoopConf.value)
+    val job = MRJob.getInstance(rc.hadoopConf.value)
 
     val stageInfo = StageInfo.deserialize(job.getConfiguration.get(StageInfo.KEY_NAME))
     FileInputFormat.setInputPaths(job, new Path(stageInfo.resolveUserVariables(path + "/*/part-*")))


### PR DESCRIPTION
## Summary

This pr modifies to use `Job.getInstance()` instead of `JobCompatibility.newJob()` to prepare for dropping hadoop1 dependency.
## Background, Problem or Goal of the patch

Asakusafw will drop hadoop1 support soon.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@ashigeru 
