### PR TITLE
Modify MapBroadcast to take multiple inputs.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/SparkClientClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/SparkClientClassBuilder.scala
@@ -152,8 +152,11 @@ class SparkClientClassBuilder(
               context.broadcastIds.getField(subPlanOutput.getOperator), {
                 val broadcast = pushNew(classOf[MapBroadcastOnce].asType)
                 broadcast.dup().invokeInit(
-                  nodeVar.push().asType(classOf[Source].asType),
-                  context.branchKeys.getField(subPlanOutput.getOperator),
+                  buildSeq { builder =>
+                    builder += tuple2(
+                      nodeVar.push().asType(classOf[Source].asType),
+                      context.branchKeys.getField(subPlanOutput.getOperator))
+                  },
                   option(
                     sortOrdering(
                       dataModelRef.groupingTypes(group.getGrouping),

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/SparkClientCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/SparkClientCompilerSpec.scala
@@ -635,6 +635,80 @@ class SparkClientCompilerSpec extends FlatSpec with LoadClassSugar with TempDirF
       val (path, classpath) = createTempDirs()
 
       spark { implicit sc =>
+        prepareData("foo", path) {
+          sc.parallelize(0 until 10).map(Foo.intToFoo)
+        }
+        prepareData("bar", path) {
+          sc.parallelize(5 until 15).map(Bar.intToBar)
+        }
+      }
+
+      val fooInputOperator = ExternalInput
+        .newInstance("foo/part-*",
+          new ExternalInputInfo.Basic(
+            ClassDescription.of(classOf[Foo]),
+            "foos",
+            ClassDescription.of(classOf[Foo]),
+            ExternalInputInfo.DataSize.UNKNOWN))
+
+      val barInputOperator = ExternalInput
+        .newInstance("bar/part-*",
+          new ExternalInputInfo.Basic(
+            ClassDescription.of(classOf[Bar]),
+            "bars",
+            ClassDescription.of(classOf[Bar]),
+            ExternalInputInfo.DataSize.UNKNOWN))
+
+      val masterCheckOperator = OperatorExtractor
+        .extract(classOf[MasterCheck], classOf[Ops], "mastercheck")
+        .input("foos", ClassDescription.of(classOf[Foo]),
+          Groups.parse(Seq("id")),
+          fooInputOperator.getOperatorPort)
+        .input("bars", ClassDescription.of(classOf[Bar]),
+          Groups.parse(Seq("fooId"), Seq("+id")),
+          barInputOperator.getOperatorPort)
+        .output("found", ClassDescription.of(classOf[Bar]))
+        .output("missed", ClassDescription.of(classOf[Bar]))
+        .build()
+
+      val foundOutputOperator = ExternalOutput
+        .newInstance("found", masterCheckOperator.findOutput("found"))
+
+      val missedOutputOperator = ExternalOutput
+        .newInstance("missed", masterCheckOperator.findOutput("missed"))
+
+      val graph = new OperatorGraph(Seq(
+        fooInputOperator, barInputOperator,
+        masterCheckOperator,
+        foundOutputOperator, missedOutputOperator))
+
+      compile(graph, 5, path, classpath)
+      execute(classpath, threshold, parallelism)
+
+      spark { implicit sc =>
+        {
+          val found = readResult[Bar]("found", path)
+            .map { bar =>
+              (bar.id.get, bar.bar.getAsString)
+            }.collect.toSeq.sortBy(_._1)
+          assert(found.size === 5)
+          assert(found === (5 until 10).map(i => (10 + i, s"bar${10 + i}")))
+        }
+        {
+          val missed = readResult[Bar]("missed", path)
+            .map { bar =>
+              (bar.id.get, bar.fooId.get, bar.bar.getAsString)
+            }.collect.toSeq.sortBy(_._1)
+          assert(missed.size === 5)
+          assert(missed === (10 until 15).map(i => (10 + i, i, s"bar${10 + i}")))
+        }
+      }
+    }
+
+    it should s"compile Spark client with MasterCheck with multiple masters: ${configuration}" in {
+      val (path, classpath) = createTempDirs()
+
+      spark { implicit sc =>
         prepareData("foo1", path) {
           sc.parallelize(0 until 5).map(Foo.intToFoo)
         }
@@ -768,6 +842,91 @@ class SparkClientCompilerSpec extends FlatSpec with LoadClassSugar with TempDirF
         foundOutputOperator, missedOutputOperator))
 
       compile(graph, 4, path, classpath)
+      execute(classpath, threshold, parallelism)
+
+      spark { implicit sc =>
+        {
+          val found = readResult[Bar]("found", path)
+            .map { bar =>
+              (bar.id.get, bar.bar.getAsString)
+            }.collect.toSeq.sortBy(_._1)
+          assert(found.size === 5)
+          assert(found === (5 until 10).map(i => (10 + i, s"bar${10 + i}")))
+        }
+        {
+          val missed = readResult[Bar]("missed", path)
+            .map { bar =>
+              (bar.id.get, bar.fooId.get, bar.bar.getAsString)
+            }.collect.toSeq.sortBy(_._1)
+          assert(missed.size === 5)
+          assert(missed === (10 until 15).map(i => (10 + i, i, s"bar${10 + i}")))
+        }
+      }
+    }
+
+    it should s"compile Spark client with broadcast MasterCheck with multiple masters: ${configuration}" in {
+      val (path, classpath) = createTempDirs()
+
+      spark { implicit sc =>
+        prepareData("foo1", path) {
+          sc.parallelize(0 until 5).map(Foo.intToFoo)
+        }
+        prepareData("foo2", path) {
+          sc.parallelize(5 until 10).map(Foo.intToFoo)
+        }
+        prepareData("bar", path) {
+          sc.parallelize(5 until 15).map(Bar.intToBar)
+        }
+      }
+
+      val foo1InputOperator = ExternalInput
+        .newInstance("foo1/part-*",
+          new ExternalInputInfo.Basic(
+            ClassDescription.of(classOf[Foo]),
+            "foos1",
+            ClassDescription.of(classOf[Foo]),
+            ExternalInputInfo.DataSize.TINY))
+
+      val foo2InputOperator = ExternalInput
+        .newInstance("foo2/part-*",
+          new ExternalInputInfo.Basic(
+            ClassDescription.of(classOf[Foo]),
+            "foos2",
+            ClassDescription.of(classOf[Foo]),
+            ExternalInputInfo.DataSize.TINY))
+
+      val barInputOperator = ExternalInput
+        .newInstance("bar/part-*",
+          new ExternalInputInfo.Basic(
+            ClassDescription.of(classOf[Bar]),
+            "bars",
+            ClassDescription.of(classOf[Bar]),
+            ExternalInputInfo.DataSize.UNKNOWN))
+
+      val masterCheckOperator = OperatorExtractor
+        .extract(classOf[MasterCheck], classOf[Ops], "mastercheck")
+        .input("foos", ClassDescription.of(classOf[Foo]),
+          Groups.parse(Seq("id")),
+          foo1InputOperator.getOperatorPort, foo2InputOperator.getOperatorPort)
+        .input("bars", ClassDescription.of(classOf[Bar]),
+          Groups.parse(Seq("fooId"), Seq("+id")),
+          barInputOperator.getOperatorPort)
+        .output("found", ClassDescription.of(classOf[Bar]))
+        .output("missed", ClassDescription.of(classOf[Bar]))
+        .build()
+
+      val foundOutputOperator = ExternalOutput
+        .newInstance("found", masterCheckOperator.findOutput("found"))
+
+      val missedOutputOperator = ExternalOutput
+        .newInstance("missed", masterCheckOperator.findOutput("missed"))
+
+      val graph = new OperatorGraph(Seq(
+        foo1InputOperator, foo2InputOperator, barInputOperator,
+        masterCheckOperator,
+        foundOutputOperator, missedOutputOperator))
+
+      compile(graph, 5, path, classpath)
       execute(classpath, threshold, parallelism)
 
       spark { implicit sc =>

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/IterativeBatchExecutorClassBuilder.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/IterativeBatchExecutorClassBuilder.scala
@@ -22,6 +22,7 @@ import scala.concurrent.ExecutionContext
 import org.apache.spark.SparkContext
 import org.objectweb.asm.{ Opcodes, Type }
 
+import com.asakusafw.lang.compiler.model.graph.MarkerOperator
 import com.asakusafw.lang.compiler.planning.{ SubPlan, Plan, Planning }
 import com.asakusafw.spark.compiler.`package`._
 import com.asakusafw.spark.compiler.planning.SubPlanInfo
@@ -167,18 +168,37 @@ class IterativeBatchExecutorClassBuilder(
           subPlanInput <- subplan.getInputs
           inputInfo <- Option(subPlanInput.getAttribute(classOf[SubPlanInputInfo]))
           if inputInfo.getInputType == SubPlanInputInfo.InputType.BROADCAST
+          broadcastInfo <- Option(subPlanInput.getAttribute(classOf[BroadcastInfo]))
         } {
           val prevSubPlanOutputs = subPlanInput.getOpposites
-          assert(prevSubPlanOutputs.size == 1,
-            s"The number of input for broadcast should be 1: ${prevSubPlanOutputs.size}")
-          val prevSubPlanOperator = prevSubPlanOutputs.head.getOperator
+          if (prevSubPlanOutputs.size == 1) {
+            val prevSubPlanOperator = prevSubPlanOutputs.head.getOperator
 
-          builder += (
-            context.broadcastIds.getField(subPlanInput.getOperator),
-            applyMap(
-              allBroadcastsVar.push(),
-              context.broadcastIds.getField(prevSubPlanOperator))
-            .cast(classOf[Broadcast].asType))
+            builder += (
+              context.broadcastIds.getField(subPlanInput.getOperator),
+              applyMap(
+                allBroadcastsVar.push(),
+                context.broadcastIds.getField(prevSubPlanOperator))
+              .cast(classOf[Broadcast].asType))
+          } else {
+            val marker = subPlanInput.getOperator
+            val iterativeInfo = IterativeInfo.get(subPlanInput)
+
+            builder += (
+              context.broadcastIds.getField(marker),
+              newBroadcast(
+                marker,
+                broadcastInfo,
+                iterativeInfo)(
+                  () => buildSeq { builder =>
+                    prevSubPlanOutputs.foreach { subPlanOutput =>
+                      builder += tuple2(
+                        nodesVar.push().aload(ldc(subplanToIdx(subPlanOutput.getOwner))),
+                        context.branchKeys.getField(subPlanOutput.getOperator))
+                    }
+                  },
+                  scVar.push))
+          }
         }
       }.store()
 
@@ -199,50 +219,65 @@ class IterativeBatchExecutorClassBuilder(
       outputInfo <- Option(subPlanOutput.getAttribute(classOf[SubPlanOutputInfo]))
       if outputInfo.getOutputType == SubPlanOutputInfo.OutputType.BROADCAST
       broadcastInfo <- Option(subPlanOutput.getAttribute(classOf[BroadcastInfo]))
+      if subPlanOutput.getOpposites.exists(_.getOpposites.size == 1)
     } {
-      val dataModelRef = subPlanOutput.getOperator.getInput.dataModelRef
-      val group = broadcastInfo.getFormatInfo
-
+      val marker = subPlanOutput.getOperator
       val iterativeInfo = IterativeInfo.get(subPlanOutput)
 
       addToMap(
         allBroadcastsVar.push(),
-        context.broadcastIds.getField(subPlanOutput.getOperator), {
-          val broadcast = iterativeInfo.getRecomputeKind match {
-            case IterativeInfo.RecomputeKind.ALWAYS =>
-              pushNew(classOf[MapBroadcastAlways].asType)
-            case IterativeInfo.RecomputeKind.PARAMETER =>
-              pushNew(classOf[MapBroadcastByParameter].asType)
-            case IterativeInfo.RecomputeKind.NEVER =>
-              pushNew(classOf[MapBroadcastOnce].asType)
-          }
-          broadcast.dup()
-          val arguments = Seq.newBuilder[Stack]
-          arguments += buildSeq { builder =>
-            builder += tuple2(
-              nodeVar.push().asType(classOf[Source].asType),
-              context.branchKeys.getField(subPlanOutput.getOperator))
-          }
-          arguments += option(
-            sortOrdering(
-              dataModelRef.groupingTypes(group.getGrouping),
-              dataModelRef.orderingTypes(group.getOrdering)))
-          arguments += groupingOrdering(dataModelRef.groupingTypes(group.getGrouping))
-          arguments += partitioner(ldc(1))
-          arguments += ldc(broadcastInfo.getLabel)
-          if (iterativeInfo.getRecomputeKind == IterativeInfo.RecomputeKind.PARAMETER) {
-            arguments +=
-              buildSet { builder =>
-                iterativeInfo.getParameters.foreach { parameter =>
-                  builder += ldc(parameter)
-                }
-              }
-          }
-          arguments += scVar.push()
-          broadcast.invokeInit(arguments.result: _*)
-          broadcast
-        })
+        context.broadcastIds.getField(marker),
+        newBroadcast(
+          marker,
+          broadcastInfo,
+          iterativeInfo)(
+            () => buildSeq { builder =>
+              builder += tuple2(
+                nodeVar.push().asType(classOf[Source].asType),
+                context.branchKeys.getField(marker))
+            },
+            scVar.push))
     }
     `return`()
+  }
+
+  private def newBroadcast(
+    marker: MarkerOperator,
+    broadcastInfo: BroadcastInfo,
+    iterativeInfo: IterativeInfo)(
+      nodes: () => Stack,
+      sc: () => Stack)(
+        implicit mb: MethodBuilder): Stack = {
+    val dataModelRef = marker.getInput.dataModelRef
+    val group = broadcastInfo.getFormatInfo
+    val broadcast = iterativeInfo.getRecomputeKind match {
+      case IterativeInfo.RecomputeKind.ALWAYS =>
+        pushNew(classOf[MapBroadcastAlways].asType)
+      case IterativeInfo.RecomputeKind.PARAMETER =>
+        pushNew(classOf[MapBroadcastByParameter].asType)
+      case IterativeInfo.RecomputeKind.NEVER =>
+        pushNew(classOf[MapBroadcastOnce].asType)
+    }
+    broadcast.dup()
+    val arguments = Seq.newBuilder[Stack]
+    arguments += nodes()
+    arguments += option(
+      sortOrdering(
+        dataModelRef.groupingTypes(group.getGrouping),
+        dataModelRef.orderingTypes(group.getOrdering)))
+    arguments += groupingOrdering(dataModelRef.groupingTypes(group.getGrouping))
+    arguments += partitioner(ldc(1))
+    arguments += ldc(broadcastInfo.getLabel)
+    if (iterativeInfo.getRecomputeKind == IterativeInfo.RecomputeKind.PARAMETER) {
+      arguments +=
+        buildSet { builder =>
+          iterativeInfo.getParameters.foreach { parameter =>
+            builder += ldc(parameter)
+          }
+        }
+    }
+    arguments += sc()
+    broadcast.invokeInit(arguments.result: _*)
+    broadcast
   }
 }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/IterativeBatchExecutorClassBuilder.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/IterativeBatchExecutorClassBuilder.scala
@@ -218,8 +218,11 @@ class IterativeBatchExecutorClassBuilder(
           }
           broadcast.dup()
           val arguments = Seq.newBuilder[Stack]
-          arguments += nodeVar.push().asType(classOf[Source].asType)
-          arguments += context.branchKeys.getField(subPlanOutput.getOperator)
+          arguments += buildSeq { builder =>
+            builder += tuple2(
+              nodeVar.push().asType(classOf[Source].asType),
+              context.branchKeys.getField(subPlanOutput.getOperator))
+          }
           arguments += option(
             sortOrdering(
               dataModelRef.groupingTypes(group.getGrouping),

--- a/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/MapBroadcastAlways.scala
+++ b/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/MapBroadcastAlways.scala
@@ -21,12 +21,11 @@ import com.asakusafw.spark.runtime.graph._
 import com.asakusafw.spark.runtime.rdd.BranchKey
 
 class MapBroadcastAlways(
-  source: Source,
-  branchKey: BranchKey,
+  prevs: Seq[(Source, BranchKey)],
   sort: Option[SortOrdering],
   group: GroupOrdering,
   partitioner: Partitioner)(
     label: String)(
       implicit sc: SparkContext)
-  extends MapBroadcast(source, branchKey, sort, group, partitioner)(label)
+  extends MapBroadcast(prevs, sort, group, partitioner)(label)
   with BroadcastAlways

--- a/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/MapBroadcastByParameter.scala
+++ b/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/MapBroadcastByParameter.scala
@@ -21,13 +21,12 @@ import com.asakusafw.spark.runtime.graph._
 import com.asakusafw.spark.runtime.rdd.BranchKey
 
 class MapBroadcastByParameter(
-  source: Source,
-  branchKey: BranchKey,
+  prevs: Seq[(Source, BranchKey)],
   sort: Option[SortOrdering],
   group: GroupOrdering,
   partitioner: Partitioner)(
     label: String)(
       val parameters: Set[String])(
         implicit sc: SparkContext)
-  extends MapBroadcast(source, branchKey, sort, group, partitioner)(label)
+  extends MapBroadcast(prevs, sort, group, partitioner)(label)
   with BroadcastByParameter

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/CoGroup.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/CoGroup.scala
@@ -29,7 +29,7 @@ import com.asakusafw.spark.runtime.rdd._
 
 abstract class CoGroup(
   @transient prevs: Seq[(Seq[(Source, BranchKey)], Option[SortOrdering])],
-  @transient grouping: GroupOrdering,
+  @transient group: GroupOrdering,
   @transient part: Partitioner)(
     @transient val broadcasts: Map[BroadcastId, Broadcast])(
       implicit @transient val sc: SparkContext)
@@ -63,10 +63,10 @@ abstract class CoGroup(
             val cogrouped = sc.smcogroup[ShuffleKey](
               prevs.map {
                 case (rdds, sort) =>
-                  (sc.confluent[ShuffleKey, Any](rdds, part, sort), sort)
+                  (sc.confluent[ShuffleKey, Any](rdds, part, sort.orElse(Option(group))), sort)
               },
               part,
-              grouping)
+              group)
 
             branch(
               cogrouped.asInstanceOf[RDD[(_, IndexedSeq[Iterator[_]])]],


### PR DESCRIPTION
## Summary

This pr modifies `MapBroadcast` to take multiple inputs.
## Background, Problem or Goal of the patch

There is a case that broadcast `MasterJoin` with multiple inputs, but currently `MapBroadcast` can't handle the case.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
