### PR TITLE
Fix ExtractCompiler to handle broadcast inputs properly.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/ExtractCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/ExtractCompiler.scala
@@ -41,12 +41,11 @@ class ExtractCompiler extends NodeCompiler {
     assert(support(subplan), s"The subplan is not supported: ${subplan}")
 
     val subPlanInfo = subplan.getAttribute(classOf[SubPlanInfo])
+    val primaryInputs = subPlanInfo.getPrimaryInputs.toSet[SubPlan.Input]
+    assert(primaryInputs.size == 1,
+      s"The size of primary inputs should be 1: ${primaryInputs.size} [${subplan}]")
 
-    val inputs = subplan.getInputs.toSet[SubPlan.Input]
-    assert(inputs.size == 1,
-      s"The size of inputs should be 1: ${inputs.size} [${subplan}]")
-
-    val marker = inputs.head.getOperator
+    val marker = primaryInputs.head.getOperator
 
     val builder =
       new ExtractClassBuilder(

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/ExtractCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/ExtractCompiler.scala
@@ -48,11 +48,11 @@ class ExtractCompiler extends RoundAwareNodeCompiler {
     assert(support(subplan), s"The subplan is not supported: ${subplan}")
 
     val subPlanInfo = subplan.getAttribute(classOf[SubPlanInfo])
+    val primaryInputs = subPlanInfo.getPrimaryInputs.toSet[SubPlan.Input]
+    assert(primaryInputs.size == 1,
+      s"The size of primary inputs should be 1: ${primaryInputs.size} [${subplan}]")
 
-    val inputs = subplan.getInputs.toSet[SubPlan.Input]
-    assert(inputs.size == 1)
-
-    val marker = inputs.head.getOperator
+    val marker = primaryInputs.head.getOperator
 
     val iterativeInfo = IterativeInfo.get(subplan)
 


### PR DESCRIPTION
## Summary

This pr fixes `ExtractCompiler` to handle broadcast inputs properly.
## Background, Problem or Goal of the patch

N/A.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
