### PR TITLE
Fix Aggregate to be able to use BatchContext.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 .worksheet
 dependency-reduced-pom.xml
 *.crc
+.tmpBin


### PR DESCRIPTION
## Summary

This pr fixes `Aggregate` to be able to use `BatchContext`.
## Background, Problem or Goal of the patch

`Aggregate` needs `ResourceBroker` to handle `BatchContext` properly.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
