### PR TITLE
Fix LoggingOperatorFragmentClassBuilder to handle logs properly.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompiler.scala
@@ -128,7 +128,11 @@ private class LoggingOperatorFragmentClassBuilder(
         val thisVar :: inputVar :: _ = mb.argVars
         invokeStatic(
           classOf[Report].asType,
-          level.name.toLowerCase,
+          level match {
+            case Logging.Level.ERROR => "error"
+            case Logging.Level.WARN => "warn"
+            case _ => "info"
+          },
           getOperatorField()
             .invokeV(
               operator.methodDesc.getName,

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompilerSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.junit.JUnitRunner
 import java.io.{ DataInput, DataOutput }
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable
 
 import org.apache.hadoop.io.Writable
 import org.apache.spark.broadcast.Broadcast
@@ -31,6 +32,7 @@ import org.apache.spark.broadcast.Broadcast
 import com.asakusafw.bridge.broker.{ ResourceBroker, ResourceSession }
 import com.asakusafw.lang.compiler.model.description.{ ClassDescription, ImmediateDescription }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
+import com.asakusafw.runtime.core.{ HadoopConfiguration, Report, ResourceConfiguration }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.{ IntOption, LongOption }
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
@@ -48,77 +50,99 @@ class LoggingOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
 
   behavior of classOf[LoggingOperatorCompiler].getSimpleName
 
-  it should "compile Logging operator" in {
-    val operator = OperatorExtractor
-      .extract(classOf[Logging], classOf[LoggingOperator], "logging")
-      .input("in", ClassDescription.of(classOf[Foo]))
-      .output("out", ClassDescription.of(classOf[Foo]))
-      .argument("n", ImmediateDescription.of(10))
-      .build()
+  for {
+    level <- Logging.Level.values
+  } {
+    it should s"compile Logging operator: Logging.Level.${level}" in {
+      val operator = OperatorExtractor
+        .extract(classOf[Logging], classOf[LoggingOperator], s"logging_${level.name.toLowerCase}")
+        .input("in", ClassDescription.of(classOf[Foo]))
+        .output("out", ClassDescription.of(classOf[Foo]))
+        .argument("n", ImmediateDescription.of(10))
+        .build()
 
-    implicit val context = newOperatorCompilerContext("flowId")
+      implicit val context = newOperatorCompilerContext("flowId")
 
-    val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
-    val cls = context.loadClass[Fragment[Foo]](thisType.getClassName)
+      val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
+      val cls = context.loadClass[Fragment[Foo]](thisType.getClassName)
 
-    val out = new GenericOutputFragment[Foo]()
+      val out = new GenericOutputFragment[Foo]()
 
-    withResourceBroker {
-      val fragment =
-        cls.getConstructor(classOf[Map[BroadcastId, Broadcast[_]]], classOf[Fragment[_]])
-          .newInstance(Map.empty, out)
-      fragment.reset()
+      withResourceBroker {
+        val fragment =
+          cls.getConstructor(classOf[Map[BroadcastId, Broadcast[_]]], classOf[Fragment[_]])
+            .newInstance(Map.empty, out)
+        fragment.reset()
 
-      val foo = new Foo()
-      for (i <- 0 until 10) {
-        foo.i.modify(i)
-        foo.l.modify(i * 10)
-        fragment.add(foo)
+        val foo = new Foo()
+        for (i <- 0 until 10) {
+          foo.i.modify(i)
+          foo.l.modify(i * 10)
+          fragment.add(foo)
+        }
+        out.iterator.zipWithIndex.foreach {
+          case (output, i) =>
+            assert(output.i.get === i)
+            assert(output.l.get === i * 10)
+        }
+
+        fragment.reset()
+
+        assert(Logs.get() ===
+          (0 until 10).map(i =>
+            (level match {
+              case Logging.Level.ERROR => "ERROR"
+              case Logging.Level.WARN => "WARN"
+              case _ => "INFO"
+            },
+              s"[${level.name}] foo: Foo(${i}, ${i * 10}), n: 10")))
       }
-      out.iterator.zipWithIndex.foreach {
-        case (output, i) =>
-          assert(output.i.get === i)
-          assert(output.l.get === i * 10)
-      }
-
-      fragment.reset()
     }
-  }
 
-  it should "compile Extract operator with projective model" in {
-    val operator = OperatorExtractor
-      .extract(classOf[Logging], classOf[LoggingOperator], "loggingp")
-      .input("in", ClassDescription.of(classOf[Foo]))
-      .output("out", ClassDescription.of(classOf[Foo]))
-      .argument("n", ImmediateDescription.of(10))
-      .build()
+    it should s"compile Extract operator with projective model: Logging.Level.${level}" in {
+      val operator = OperatorExtractor
+        .extract(classOf[Logging], classOf[LoggingOperator], s"loggingp_${level.name.toLowerCase}")
+        .input("in", ClassDescription.of(classOf[Foo]))
+        .output("out", ClassDescription.of(classOf[Foo]))
+        .argument("n", ImmediateDescription.of(10))
+        .build()
 
-    implicit val context = newOperatorCompilerContext("flowId")
+      implicit val context = newOperatorCompilerContext("flowId")
 
-    val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
-    val cls = context.loadClass[Fragment[Foo]](thisType.getClassName)
+      val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
+      val cls = context.loadClass[Fragment[Foo]](thisType.getClassName)
 
-    val out = new GenericOutputFragment[Foo]()
+      val out = new GenericOutputFragment[Foo]()
 
-    withResourceBroker {
-      val fragment =
-        cls.getConstructor(classOf[Map[BroadcastId, Broadcast[_]]], classOf[Fragment[_]])
-          .newInstance(Map.empty, out)
+      withResourceBroker {
+        val fragment =
+          cls.getConstructor(classOf[Map[BroadcastId, Broadcast[_]]], classOf[Fragment[_]])
+            .newInstance(Map.empty, out)
 
-      fragment.reset()
-      val foo = new Foo()
-      for (i <- 0 until 10) {
-        foo.i.modify(i)
-        foo.l.modify(i * 10)
-        fragment.add(foo)
+        fragment.reset()
+        val foo = new Foo()
+        for (i <- 0 until 10) {
+          foo.i.modify(i)
+          foo.l.modify(i * 10)
+          fragment.add(foo)
+        }
+        out.iterator.zipWithIndex.foreach {
+          case (output, i) =>
+            assert(output.i.get === i)
+            assert(output.l.get === i * 10)
+        }
+
+        fragment.reset()
+
+        assert(Logs.get() ===
+          (0 until 10).map(i =>
+            (level match {
+              case Logging.Level.ERROR => "ERROR"
+              case Logging.Level.WARN => "WARN"
+              case _ => "INFO"
+            },
+              s"[${level.name}] f: F(${i}), n: 10")))
       }
-      out.iterator.zipWithIndex.foreach {
-        case (output, i) =>
-          assert(output.i.get === i)
-          assert(output.l.get === i * 10)
-      }
-
-      fragment.reset()
     }
   }
 
@@ -126,7 +150,11 @@ class LoggingOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
     val session = ResourceBroker.attach(
       ResourceBroker.Scope.THREAD,
       new ResourceBroker.Initializer {
-        override def accept(session: ResourceSession): Unit = {}
+        override def accept(session: ResourceSession): Unit = {
+          val conf = new HadoopConfiguration()
+          conf.set("com.asakusafw.runtime.core.Report.Delegate", classOf[Delegate].getName)
+          session.put(classOf[ResourceConfiguration], conf)
+        }
       })
     try {
       block
@@ -137,6 +165,21 @@ class LoggingOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
 }
 
 object LoggingOperatorCompilerSpec {
+
+  val Logs = new ThreadLocal[mutable.ArrayBuffer[(String, String)]] {
+    override def initialValue() = mutable.ArrayBuffer.empty
+  }
+
+  class Delegate extends Report.Delegate {
+
+    override def report(level: Report.Level, message: String): Unit = {
+      Logs.get() += ((level.name, message))
+    }
+
+    override def cleanup(conf: ResourceConfiguration): Unit = {
+      Logs.get().clear()
+    }
+  }
 
   trait FooP {
     def getIOption: IntOption
@@ -170,18 +213,60 @@ object LoggingOperatorCompilerSpec {
 
   class LoggingOperator {
 
-    @Logging
-    def logging(
+    @Logging(Logging.Level.ERROR)
+    def logging_error(
       foo: Foo,
       n: Int): String = {
-      s"foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
+      s"[ERROR] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
     }
 
-    @Logging
-    def loggingp[F <: FooP](
+    @Logging(Logging.Level.ERROR)
+    def loggingp_error[F <: FooP](
       f: F,
       n: Int): String = {
-      s"f: F(${f.getIOption.get}), n: ${n}"
+      s"[ERROR] f: F(${f.getIOption.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.WARN)
+    def logging_warn(
+      foo: Foo,
+      n: Int): String = {
+      s"[WARN] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.WARN)
+    def loggingp_warn[F <: FooP](
+      f: F,
+      n: Int): String = {
+      s"[WARN] f: F(${f.getIOption.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.INFO)
+    def logging_info(
+      foo: Foo,
+      n: Int): String = {
+      s"[INFO] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.INFO)
+    def loggingp_info[F <: FooP](
+      f: F,
+      n: Int): String = {
+      s"[INFO] f: F(${f.getIOption.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.DEBUG)
+    def logging_debug(
+      foo: Foo,
+      n: Int): String = {
+      s"[DEBUG] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.DEBUG)
+    def loggingp_debug[F <: FooP](
+      f: F,
+      n: Int): String = {
+      s"[DEBUG] f: F(${f.getIOption.get}), n: ${n}"
     }
   }
 }


### PR DESCRIPTION
## Summary

This pr fixes `LoggingOperatorFragmentClassBuilder` to handle logs properly.
## Background, Problem or Goal of the patch

`LoggingOperatorFragment` compiled by `LoggingOperatorFragmentClassBuilder` can't handle `@Logging` operator with `Logging.Level.DEBUG` because `Report` class doesn't have `debug()` method.
## Design of the fix, or a new feature

Make `LoggingOperatorFragmentClassBuilder` use `Report.error()` method for `Logging.Level.ERROR`, `Report.warn()` method for `Logging.Level.WARN` and `Report.info()` method for otherwise, which is the same as `MapReduce` implementation.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
