### PR TITLE
Fix DirectOutputPrepare to handle batch argument properly.

### DIFF
--- a/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareForIterativeClassBuilderSpec.scala
+++ b/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareForIterativeClassBuilderSpec.scala
@@ -278,6 +278,128 @@ class DirectOutputPrepareForIterativeClassBuilderSpec
         idx += 1
       }
 
+      it should s"prepare flat simple with batch argument: [${conf}]" in {
+        val foosMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+          .attribute(classOf[PlanMarker], PlanMarker.GATHER).build()
+        val endMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+          .attribute(classOf[PlanMarker], PlanMarker.END).build()
+
+        val outputOperator = ExternalOutput.builder(
+          s"flat${idx}",
+          new ExternalOutputInfo.Basic(
+            ClassDescription.of(classOf[DirectFileOutputModel]),
+            DirectFileIoConstants.MODULE_NAME,
+            ClassDescription.of(classOf[Foo]),
+            Descriptions.valueOf(
+              new DirectFileOutputModel(
+                DirectOutputDescription(
+                  basePath = s"test/flat${idx}_$${arg}_$${round}",
+                  resourcePattern = "${arg}_*.bin",
+                  order = Seq.empty,
+                  deletePatterns = Seq("*.bin"),
+                  formatType = classOf[FooSequenceFileFormat])))))
+          .input(ExternalOutput.PORT_NAME, ClassDescription.of(classOf[Foo]), foosMarker.getOutput)
+          .output("end", ClassDescription.of(classOf[Foo]))
+          .build()
+        outputOperator.findOutput("end").connect(endMarker.getInput)
+
+        val plan = PlanBuilder.from(Seq(outputOperator))
+          .add(
+            Seq(foosMarker),
+            Seq(endMarker)).build().getPlan()
+        assert(plan.getElements.size === 1)
+
+        val subplan = plan.getElements.head
+        subplan.putAttr(
+          new SubPlanInfo(_,
+            SubPlanInfo.DriverType.OUTPUT,
+            Seq.empty[SubPlanInfo.DriverOption],
+            outputOperator))
+        subplan.putAttr(_ => iterativeInfo)
+
+        val foosInput = subplan.findIn(foosMarker)
+
+        implicit val context = newNodeCompilerContext(flowId, classServer.root.toFile)
+        context.branchKeys.getField(foosInput.getOperator.getSerialNumber)
+
+        val rounds = 0 to 1
+        val numSlices = 2
+        val files = rounds.map { round =>
+          (0 until numSlices).map(i => new File(root, s"flat${idx}_bar_${round}/bar_s${round + stageOffset}-p${i}.bin"))
+        }
+
+        implicit val jobContext = newJobContext(sc)
+
+        val source =
+          new RoundAwareParallelCollectionSource(Input, 0 until 100, Some(numSlices))("input")
+            .mapWithRoundContext(Input)(Foo.intToFoo)
+
+        val setup = new Setup("setup")
+        val prepareEach = newPrepareFlatEach(subplan)(Seq((source, Input)))
+        val prepare = newPrepare(subplan)(setup, prepareEach)
+        val commit = new Commit(prepare)(s"test/flat${idx}_$${round}")
+
+        val origin = newRoundContext()
+        val rcs = rounds.map { round =>
+          newRoundContext(
+            stageId = s"round_${round}",
+            batchArguments = Map("arg" -> "bar", "round" -> round.toString))
+        }
+
+        assert(files.exists(_.exists(_.exists())) === false)
+
+        rcs.foreach { rc =>
+          Await.result(prepareEach.perform(rc), Duration.Inf)
+        }
+
+        Await.result(prepare.perform(origin, rcs), Duration.Inf)
+        assert(files.exists(_.exists(_.exists())) === false)
+
+        Await.result(commit.perform(origin, rcs), Duration.Inf)
+        if (iterativeInfo.getRecomputeKind != IterativeInfo.RecomputeKind.NEVER) {
+          assert(files.forall(_.forall(_.exists())) === true)
+
+          rounds.foreach { round =>
+            assert(
+              sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
+                new File(root, s"flat${idx}_bar_${round}/bar_s${round + stageOffset}-*.bin").getAbsolutePath)
+                .map(_._2)
+                .map(foo => (foo.id.get, foo.group.get))
+                .collect.toSeq
+                === (0 until 100).map(i => (100 * round + i, i % 10)))
+          }
+
+          assert(jobContext.outputStatistics(Direct).size === 1)
+          val statistics = jobContext.outputStatistics(Direct)(outputOperator.getName)
+          assert(statistics.files === 4)
+          assert(statistics.bytes === 4292)
+          assert(statistics.records === 200)
+
+          stageOffset += 7
+        } else {
+          assert(files.head.forall(_.exists()) === true)
+          assert(files.tail.exists(_.exists(_.exists())) === false)
+
+          val round = rounds.head
+          assert(
+            sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
+              new File(root, s"flat${idx}_bar_${round}/bar_s${round + stageOffset}-*.bin").getAbsolutePath)
+              .map(_._2)
+              .map(foo => (foo.id.get, foo.group.get))
+              .collect.toSeq
+              === (0 until 100).map(i => (100 * round + i, i % 10)))
+
+          assert(jobContext.outputStatistics(Direct).size === 1)
+          val statistics = jobContext.outputStatistics(Direct)(outputOperator.getName)
+          assert(statistics.files === 2)
+          assert(statistics.bytes === 2146)
+          assert(statistics.records === 100)
+
+          stageOffset += 4
+        }
+        idx += 1
+      }
+
       it should s"prepare flat w/o round variable: [${conf}]" in {
         val foosMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
           .attribute(classOf[PlanMarker], PlanMarker.GATHER).build()
@@ -586,6 +708,133 @@ class DirectOutputPrepareForIterativeClassBuilderSpec
           newRoundContext(
             stageId = s"round_${round}",
             batchArguments = Map("round" -> round.toString))
+        }
+
+        assert(files.exists(_.exists(_.exists())) === false)
+
+        rcs.foreach { rc =>
+          Await.result(prepareEach.perform(rc), Duration.Inf)
+        }
+
+        Await.result(prepare.perform(origin, rcs), Duration.Inf)
+        assert(files.exists(_.exists(_.exists())) === false)
+
+        Await.result(commit.perform(origin, rcs), Duration.Inf)
+        if (iterativeInfo.getRecomputeKind != IterativeInfo.RecomputeKind.NEVER) {
+          assert(files.forall(_.forall(_.exists())) === true)
+
+          rounds.zip(files).foreach {
+            case (round, files) =>
+              files.zipWithIndex.foreach {
+                case (file, i) =>
+                  assert(
+                    sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
+                      file.getAbsolutePath)
+                      .map(_._2)
+                      .map(foo => (foo.id.get, foo.group.get))
+                      .collect.toSeq
+                      === (0 until 100).reverse.filter(_ % 10 == i).map(j => (100 * round + j, i)))
+              }
+          }
+
+          assert(jobContext.outputStatistics(Direct).size === 1)
+          val statistics = jobContext.outputStatistics(Direct)(outputOperator.getName)
+          assert(statistics.files === 20)
+          assert(statistics.bytes === 7060)
+          assert(statistics.records === 200)
+
+        } else {
+          assert(files.head.forall(_.exists()) === true)
+          assert(files.tail.exists(_.exists(_.exists())) === false)
+
+          val round = rounds.head
+          files.head.zipWithIndex.foreach {
+            case (file, i) =>
+              assert(
+                sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
+                  file.getAbsolutePath)
+                  .map(_._2)
+                  .map(foo => (foo.id.get, foo.group.get))
+                  .collect.toSeq
+                  === (0 until 100).reverse.filter(_ % 10 == i).map(j => (100 * round + j, i)))
+          }
+
+          assert(jobContext.outputStatistics(Direct).size === 1)
+          val statistics = jobContext.outputStatistics(Direct)(outputOperator.getName)
+          assert(statistics.files === 10)
+          assert(statistics.bytes === 3530)
+          assert(statistics.records === 100)
+        }
+        idx += 1
+      }
+
+      it should s"prepare group simple with batch argument: [${conf}]" in {
+        val foosMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+          .attribute(classOf[PlanMarker], PlanMarker.GATHER).build()
+        val endMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+          .attribute(classOf[PlanMarker], PlanMarker.END).build()
+
+        val outputOperator = ExternalOutput.builder(
+          s"group${idx}",
+          new ExternalOutputInfo.Basic(
+            ClassDescription.of(classOf[DirectFileOutputModel]),
+            DirectFileIoConstants.MODULE_NAME,
+            ClassDescription.of(classOf[Foo]),
+            Descriptions.valueOf(
+              new DirectFileOutputModel(
+                DirectOutputDescription(
+                  basePath = s"test/group${idx}_$${arg}_$${round}",
+                  resourcePattern = "foo_${arg}_{group}.bin",
+                  order = Seq("-id"),
+                  deletePatterns = Seq("*.bin"),
+                  formatType = classOf[FooSequenceFileFormat])))))
+          .input(ExternalOutput.PORT_NAME, ClassDescription.of(classOf[Foo]), foosMarker.getOutput)
+          .output("end", ClassDescription.of(classOf[Foo]))
+          .build()
+        outputOperator.findOutput("end").connect(endMarker.getInput)
+
+        val plan = PlanBuilder.from(Seq(outputOperator))
+          .add(
+            Seq(foosMarker),
+            Seq(endMarker)).build().getPlan()
+        assert(plan.getElements.size === 1)
+
+        val subplan = plan.getElements.head
+        subplan.putAttr(
+          new SubPlanInfo(_,
+            SubPlanInfo.DriverType.OUTPUT,
+            Seq.empty[SubPlanInfo.DriverOption],
+            outputOperator))
+        subplan.putAttr(_ => iterativeInfo)
+
+        val foosInput = subplan.findIn(foosMarker)
+
+        implicit val context = newNodeCompilerContext(flowId, classServer.root.toFile)
+        context.branchKeys.getField(foosInput.getOperator.getSerialNumber)
+
+        val rounds = 0 to 1
+        val numSlices = 2
+        val files = rounds.map { round =>
+          (0 until numSlices).map(i => new File(root, s"group${idx}_bar_${round}/foo_bar_${i}.bin"))
+        }
+
+        implicit val jobContext = newJobContext(sc)
+
+        val source =
+          new RoundAwareParallelCollectionSource(Input, 0 until 100, Some(numSlices))("input")
+            .mapWithRoundContext(Input)(Foo.intToFoo)
+
+        val setup = new Setup("setup")
+        val prepareEach = newPrepareGroupEach(subplan)(
+          Seq((source, Input)))(new HashPartitioner(sc.defaultParallelism))
+        val prepare = newPrepare(subplan)(setup, prepareEach)
+        val commit = new Commit(prepare)(s"test/group${idx}_$${round}")
+
+        val origin = newRoundContext()
+        val rcs = rounds.map { round =>
+          newRoundContext(
+            stageId = s"round_${round}",
+            batchArguments = Map("arg" -> "bar", "round" -> round.toString))
         }
 
         assert(files.exists(_.exists(_.exists())) === false)

--- a/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/DirectOutputPrepareEachForIterative.scala
+++ b/extensions/iterativebatch/runtime/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/runtime/graph/DirectOutputPrepareEachForIterative.scala
@@ -180,9 +180,9 @@ abstract class DirectOutputPrepareGroupEachForIterative[T <: DataModel[T] with W
 
   def orderings(value: T): Seq[ValueOption[_]]
 
-  def shuffleKey(basePathOpt: StringOption, value: T): ShuffleKey = {
+  def shuffleKey(basePathOpt: StringOption, value: T)(stageInfo: StageInfo): ShuffleKey = {
     new ShuffleKey(
-      WritableSerDe.serialize(Seq(basePathOpt, outputPatternGenerator.generate(value))),
+      WritableSerDe.serialize(Seq(basePathOpt, outputPatternGenerator.generate(value)(stageInfo))),
       WritableSerDe.serialize(orderings(value)))
   }
 
@@ -198,7 +198,7 @@ abstract class DirectOutputPrepareGroupEachForIterative[T <: DataModel[T] with W
       basePathOpt.modify(stageInfo.resolveUserVariables(this.basePath))
 
       iter.map { value =>
-        (shuffleKey(basePathOpt, value), WritableSerDe.serialize(value))
+        (shuffleKey(basePathOpt, value)(stageInfo), WritableSerDe.serialize(value))
       }
     }
       .repartitionAndSortWithinPartitions(partitioner)

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/directio/OutputPatternGenerator.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/directio/OutputPatternGenerator.scala
@@ -18,6 +18,7 @@ package com.asakusafw.spark.runtime.directio
 import java.text.SimpleDateFormat
 import java.util.{ Calendar, Random }
 
+import com.asakusafw.bridge.stage.StageInfo
 import com.asakusafw.runtime.value._
 import com.asakusafw.spark.runtime.directio.OutputPatternGenerator._
 
@@ -27,9 +28,9 @@ abstract class OutputPatternGenerator[T](fragments: Seq[Fragment]) {
 
   def getProperty(target: T, name: String): ValueOption[_]
 
-  def generate(target: T): StringOption = {
+  def generate(target: T)(stageInfo: StageInfo): StringOption = {
     val str = fragments.map {
-      case Fragment.Constant(value) => value
+      case Fragment.Constant(value) => stageInfo.resolveUserVariables(value)
       case Fragment.Natural(property) => getProperty(target, property)
       case date: Fragment.DateFormat =>
         date.format(getProperty(target, date.property))

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/StageInfoSugar.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/StageInfoSugar.scala
@@ -22,40 +22,16 @@ import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.bridge.stage.StageInfo
 
-trait RoundContextSugar extends StageInfoSugar {
+trait StageInfoSugar {
 
-  def newRoundContext(stageInfo: StageInfo)(implicit jobContext: JobContext): RoundContext = {
-    val conf = new Configuration(jobContext.sparkContext.hadoopConfiguration)
-    conf.set(StageInfo.KEY_NAME, stageInfo.serialize)
-
-    RoundContextSugar.MockRoundContext(jobContext.sparkContext.broadcast(conf))
-  }
-
-  def newRoundContext(
+  def newStageInfo(
     userName: String = sys.props("user.name"),
     batchId: String = "batchId",
     flowId: String = "flowId",
     stageId: String = null,
     executionId: String = "executionId",
-    batchArguments: Map[String, String] = Map.empty)(
-      implicit jobContext: JobContext): RoundContext = {
+    batchArguments: Map[String, String] = Map.empty): StageInfo = {
 
-    val stageInfo = newStageInfo(userName, batchId, flowId, stageId, executionId, batchArguments)
-    newRoundContext(stageInfo)
-  }
-}
-
-object RoundContextSugar {
-
-  case class MockRoundContext(hadoopConf: Broadcasted[Configuration]) extends RoundContext {
-
-    private def stageInfo: StageInfo =
-      StageInfo.deserialize(hadoopConf.value.get(StageInfo.KEY_NAME))
-
-    override lazy val roundId: Option[String] = {
-      Option(stageInfo.getStageId)
-    }
-
-    override lazy val toString: String = stageInfo.toString
+    new StageInfo(userName, batchId, flowId, stageId, executionId, batchArguments)
   }
 }

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/DirectOutputPrepareSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/DirectOutputPrepareSpec.scala
@@ -68,50 +68,102 @@ class DirectOutputPrepareSpec
     conf.setHadoopConf("com.asakusafw.directio.test.fs.path", root.getAbsolutePath)
   }
 
-  it should "prepare flat" in {
-    implicit val jobContext = newJobContext(sc)
+  {
+    var stageOffset = 0
 
-    val numSlices = 2
-    val files = (0 until numSlices).map(i => new File(root, s"flat/s0-p${i}.bin"))
+    it should "prepare flat" in {
+      implicit val jobContext = newJobContext(sc)
 
-    val source =
-      new ParallelCollectionSource(Input, 0 until 100, Some(numSlices))("input")
-        .map(Input)(Foo.intToFoo)
+      val numSlices = 2
+      val files = (0 until numSlices).map(i => new File(root, s"flat/s${stageOffset}-p${i}.bin"))
 
-    val setup = new Setup("setup")
-    val prepare = new Flat.Prepare(
-      setup,
-      Seq((source, Input)))(
-      "flat",
-      "test/flat",
-      "*.bin",
-      classOf[FooSequenceFileFormat])(
-      "flat")
-    val commit = new Commit(prepare)("test/flat")
+      val source =
+        new ParallelCollectionSource(Input, 0 until 100, Some(numSlices))("input")
+          .map(Input)(Foo.intToFoo)
 
-    val rc = newRoundContext()
+      val setup = new Setup("setup")
+      val prepare = new Flat.Prepare(
+        setup,
+        Seq((source, Input)))(
+        "flat",
+        "test/flat",
+        "*.bin",
+        classOf[FooSequenceFileFormat])(
+        "flat")
+      val commit = new Commit(prepare)("test/flat")
 
-    assert(files.exists(_.exists()) === false)
+      val rc = newRoundContext()
 
-    Await.result(prepare.perform(rc), Duration.Inf)
-    assert(files.exists(_.exists()) === false)
+      assert(files.exists(_.exists()) === false)
 
-    Await.result(commit.perform(rc), Duration.Inf)
-    assert(files.forall(_.exists()) === true)
+      Await.result(prepare.perform(rc), Duration.Inf)
+      assert(files.exists(_.exists()) === false)
 
-    assert(
-      sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
-        new File(root, "flat/s0-*.bin").getAbsolutePath)
-        .map(_._2)
-        .map(foo => (foo.id.get, foo.group.get))
-        .collect.toSeq
-        === (0 until 100).map(i => (i, i % 10)))
+      Await.result(commit.perform(rc), Duration.Inf)
+      assert(files.forall(_.exists()) === true)
 
-    assert(jobContext.outputStatistics(Direct).size === 1)
-    val statistics = jobContext.outputStatistics(Direct)("flat")
-    assert(statistics.files === 2)
-    assert(statistics.bytes === 2044)
-    assert(statistics.records === 100)
+      assert(
+        sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
+          new File(root, s"flat/s${stageOffset}-*.bin").getAbsolutePath)
+          .map(_._2)
+          .map(foo => (foo.id.get, foo.group.get))
+          .collect.toSeq
+          === (0 until 100).map(i => (i, i % 10)))
+
+      assert(jobContext.outputStatistics(Direct).size === 1)
+      val statistics = jobContext.outputStatistics(Direct)("flat")
+      assert(statistics.files === 2)
+      assert(statistics.bytes === 2044)
+      assert(statistics.records === 100)
+
+      stageOffset += 2
+    }
+
+    it should "prepare flat with batch argument" in {
+      implicit val jobContext = newJobContext(sc)
+
+      val numSlices = 2
+      val files = (0 until numSlices).map(i => new File(root, s"flat_bar/bar_s${stageOffset}-p${i}.bin"))
+
+      val source =
+        new ParallelCollectionSource(Input, 0 until 100, Some(numSlices))("input")
+          .map(Input)(Foo.intToFoo)
+
+      val setup = new Setup("setup")
+      val prepare = new Flat.Prepare(
+        setup,
+        Seq((source, Input)))(
+        "flat",
+        "test/flat_${arg}",
+        "${arg}_*.bin",
+        classOf[FooSequenceFileFormat])(
+        "flat")
+      val commit = new Commit(prepare)("test/flat")
+
+      val rc = newRoundContext(batchArguments = Map("arg" -> "bar"))
+
+      assert(files.exists(_.exists()) === false)
+
+      Await.result(prepare.perform(rc), Duration.Inf)
+      assert(files.exists(_.exists()) === false)
+
+      Await.result(commit.perform(rc), Duration.Inf)
+      assert(files.forall(_.exists()) === true)
+
+      assert(
+        sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
+          new File(root, s"flat_bar/bar_s${stageOffset}-*.bin").getAbsolutePath)
+          .map(_._2)
+          .map(foo => (foo.id.get, foo.group.get))
+          .collect.toSeq
+          === (0 until 100).map(i => (i, i % 10)))
+
+      assert(jobContext.outputStatistics(Direct).size === 1)
+      val statistics = jobContext.outputStatistics(Direct)("flat")
+      assert(statistics.files === 2)
+      assert(statistics.bytes === 2044)
+      assert(statistics.records === 100)
+    }
   }
 
   it should "prepare group" in {
@@ -132,11 +184,63 @@ class DirectOutputPrepareSpec
       new HashPartitioner(sc.defaultParallelism))(
       "group",
       "test/group",
-      classOf[FooSequenceFileFormat])(
+      classOf[FooSequenceFileFormat],
+      Seq(constant("foo_"), natural("group"), constant(".bin")))(
       "group")
     val commit = new Commit(prepare)("test/group")
 
     val rc = newRoundContext()
+
+    assert(files.exists(_.exists()) === false)
+
+    Await.result(prepare.perform(rc), Duration.Inf)
+    assert(files.exists(_.exists()) === false)
+
+    Await.result(commit.perform(rc), Duration.Inf)
+    assert(files.forall(_.exists()) === true)
+
+    files.zipWithIndex.foreach {
+      case (file, i) =>
+        assert(
+          sc.newAPIHadoopFile[NullWritable, Foo, SequenceFileInputFormat[NullWritable, Foo]](
+            file.getAbsolutePath)
+            .map(_._2)
+            .map(foo => (foo.id.get, foo.group.get))
+            .collect.toSeq
+            === (0 until 100).reverse.filter(_ % 10 == i).map(j => (j, i)))
+    }
+
+    assert(jobContext.outputStatistics(Direct).size === 1)
+    val statistics = jobContext.outputStatistics(Direct)("group")
+    assert(statistics.files === 10)
+    assert(statistics.bytes === 3020)
+    assert(statistics.records === 100)
+  }
+
+  it should "prepare group with batch argument" in {
+    implicit val jobContext = newJobContext(sc)
+
+    val numSlices = 2
+    val files = (0 until 10).map(i => new File(root, s"group_bar/foo_bar_${i}.bin"))
+
+    val source =
+      new ParallelCollectionSource(Input,
+        (0 until 100).map(i => (i, math.random)).sortBy(_._2).map(_._1), Some(numSlices))("input")
+        .map(Input)(Foo.intToFoo)
+
+    val setup = new Setup("setup")
+    val prepare = new Group.Prepare(
+      setup,
+      Seq((source, Input)))(
+      new HashPartitioner(sc.defaultParallelism))(
+      "group",
+      "test/group_${arg}",
+      classOf[FooSequenceFileFormat],
+      Seq(constant("foo_${arg}_"), natural("group"), constant(".bin")))(
+      "group")
+    val commit = new Commit(prepare)("test/group")
+
+    val rc = newRoundContext(batchArguments = Map("arg" -> "bar"))
 
     assert(files.exists(_.exists()) === false)
 
@@ -269,14 +373,14 @@ object DirectOutputPrepareSpec {
         partitioner: Partitioner)(
           val name: String,
           val basePath: String,
-          val formatType: Class[_ <: DataFormat[Foo]])(
+          val formatType: Class[_ <: DataFormat[Foo]],
+          val fragments: Seq[Fragment])(
             val label: String)(
               implicit jobContext: JobContext)
       extends DirectOutputPrepareGroup[Foo](setup, prevs)(partitioner)
       with CacheOnce[RoundContext, Future[Unit]] {
 
-      override lazy val outputPatternGenerator = new FooOutputPatternGenerator(
-        Seq(constant("foo_"), natural("group"), constant(".bin")))
+      override lazy val outputPatternGenerator = new FooOutputPatternGenerator(fragments)
 
       override val sortOrdering: SortOrdering = new Ord
 


### PR DESCRIPTION
## Summary

This pr fixes `DirectOutputPrepare` to handle batch argument properly.
## Background, Problem or Goal of the patch

`DirectOutputPrepare` doesn't resolve user variables when it prepares resource path without wildcard.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
