### PR TITLE
Support `*Tester.configure()` in Spark tasks.

### DIFF
--- a/test-adapter/src/main/java/com/asakusafw/spark/testdriver/adapter/SparkCompilerProfileInitializer.java
+++ b/test-adapter/src/main/java/com/asakusafw/spark/testdriver/adapter/SparkCompilerProfileInitializer.java
@@ -15,10 +15,13 @@
  */
 package com.asakusafw.spark.testdriver.adapter;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.extension.redirector.RedirectorParticipant;
 import com.asakusafw.lang.compiler.testdriver.adapter.CompilerProfileInitializer;
 import com.asakusafw.lang.compiler.tester.CompilerProfile;
@@ -26,8 +29,12 @@ import com.asakusafw.testdriver.compiler.CompilerConfiguration;
 
 /**
  * {@link CompilerProfileInitializer} for Spark.
+ * @since 0.1.0
+ * @version 0.4.0
  */
 public class SparkCompilerProfileInitializer implements CompilerProfileInitializer {
+
+    private static final String COMMAND_PATH = "spark/bin/spark-execute.sh"; //$NON-NLS-1$
 
     private static final Map<String, String> REDIRECT_MAP;
     static {
@@ -49,15 +56,20 @@ public class SparkCompilerProfileInitializer implements CompilerProfileInitializ
     }
 
     @Override
+    public Collection<Location> getLauncherPaths() {
+        return Arrays.asList(Location.of(COMMAND_PATH));
+    }
+
+    @Override
     public void initialize(CompilerProfile profile, CompilerConfiguration configuration) {
         installOptions(REDIRECT_MAP, profile, configuration);
     }
 
-    private void installOptions(
+    private static void installOptions(
             Map<String, String> options,
             CompilerProfile profile,
             CompilerConfiguration configuration) {
-        for (Map.Entry<String, String> entry : REDIRECT_MAP.entrySet()) {
+        for (Map.Entry<String, String> entry : options.entrySet()) {
             String key = entry.getKey();
             if (configuration.getOptions().containsKey(key) == false) {
                 profile.forCompilerOptions().withProperty(key, entry.getValue());


### PR DESCRIPTION
## Summary

This PR enables Asakusa on Spark testkit use `*Tester.configure()`.
## Background, Problem or Goal of the patch

see asakusafw/asakusafw#688.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code
- asakusafw/asakusafw#688
- asakusafw/asakusafw-compiler#86
## Wanted reviewer

@akirakw 
