### PR TITLE
Remove `Task.leftShift()` in Gradle plug-ins.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkBasePlugin.groovy
@@ -149,7 +149,7 @@ class AsakusaSparkBasePlugin implements Plugin<Project> {
     }
 
     private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
+        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS).doLast {
             logger.lifecycle "Asakusa on Spark: ${extension.featureVersion}"
         }
     }

--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPlugin.groovy
@@ -126,7 +126,7 @@ class AsakusaSparkSdkPlugin implements Plugin<Project> {
     }
 
     private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
+        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS).doLast {
             def sparkVersion = 'INVALID'
             try {
                 logger.info 'detecting Spark version'


### PR DESCRIPTION
## Summary

This PR replaces `Task.leftShift()` with `Task.doLast()` in Gradle plug-ins.
## Background, Problem or Goal of the patch

`Task.leftShift()` will have become deprecated from Gradle `3.2`.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code

N/A.
## Wanted reviewer

@akirakw 
