### PR TITLE
Initialize ApiActivators to be able to use old batch APIs.

### DIFF
--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/ResourceBrokingIterator.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/ResourceBrokingIterator.scala
@@ -16,14 +16,19 @@
 package com.asakusafw.spark.runtime
 package graph
 
+import scala.collection.JavaConversions._
+
 import org.apache.hadoop.conf.Configuration
 
+import com.asakusafw.bridge.api.activate.ApiActivator
 import com.asakusafw.bridge.broker.{ ResourceBroker, ResourceSession }
 import com.asakusafw.bridge.stage.StageInfo
 import com.asakusafw.runtime.core.{ HadoopConfiguration, ResourceConfiguration }
 
 class ResourceBrokingIterator[+T](val hadoopConf: Configuration, _delegate: => Iterator[T])
   extends Iterator[T] {
+
+  val _ = ResourceBrokingIterator.activators // Initialize activators.
 
   val session = ResourceBroker.attach(
     ResourceBroker.Scope.THREAD,
@@ -46,4 +51,9 @@ class ResourceBrokingIterator[+T](val hadoopConf: Configuration, _delegate: => I
   }
 
   def next(): T = delegate.next()
+}
+
+object ResourceBrokingIterator {
+
+  val activators = ApiActivator.load(Thread.currentThread.getContextClassLoader).map(_.activate)
 }


### PR DESCRIPTION
## Summary

This pr adds initialization of `ApiActivators` to be able to use old batch APIs.

## Background, Problem or Goal of the patch

Usually old batch APIs are replaced by new APIs while compiling applications, but there are user libraries referring to old batch APIs.
We need to activate to use them.

## Design of the fix, or a new feature

Added initialization of `ApiActivators` and activation of them.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@ashigeru, @akirakw 
