### PR TITLE
Enable SparkPlanning to handle `View` inputs.

### DIFF
--- a/planner/src/test/java/com/asakusafw/spark/compiler/planning/PlanningTestRoot.java
+++ b/planner/src/test/java/com/asakusafw/spark/compiler/planning/PlanningTestRoot.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -44,6 +45,7 @@ import com.asakusafw.lang.compiler.model.info.JobflowInfo;
 import com.asakusafw.lang.compiler.model.testing.MockOperators;
 import com.asakusafw.lang.compiler.planning.PlanDetail;
 import com.asakusafw.lang.compiler.planning.SubPlan;
+import com.asakusafw.spark.compiler.planning.SubPlanInputInfo.InputOption;
 
 /**
  * A common test base class for planning.
@@ -252,6 +254,33 @@ public abstract class PlanningTestRoot {
         Set<? extends SubPlan.Input> inputs = sub.getInputs();
         assertThat(inputs, hasSize(1));
         return inputs.iterator().next();
+    }
+
+    /**
+     * Returns the singular primary input.
+     * @param sub the target sub-plan
+     * @return the singular input
+     */
+    public static SubPlan.Input primary(SubPlan sub) {
+        List<? extends SubPlan.Input> inputs = sub.getInputs().stream()
+                .filter(p -> p.getAttribute(SubPlanInputInfo.class).getInputOptions().contains(InputOption.PRIMARY))
+                .collect(Collectors.toList());
+        assertThat(inputs, hasSize(1));
+        return inputs.get(0);
+    }
+
+    /**
+     * Returns the singular secondary input.
+     * @param sub the target sub-plan
+     * @return the singular input
+     */
+    public static SubPlan.Input secondary(SubPlan sub) {
+        List<? extends SubPlan.Input> inputs = sub.getInputs().stream()
+                .filter(p -> p.getAttribute(SubPlanInputInfo.class).getInputOptions()
+                        .contains(InputOption.PRIMARY) == false)
+                .collect(Collectors.toList());
+        assertThat(inputs, hasSize(1));
+        return inputs.get(0);
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR enables `SparkPlanning` accept view features (asakusafw/asakusafw#700).

## Background, Problem or Goal of the patch

see asakusafw/asakusafw#700

## Design of the fix, or a new feature

In asakusafw/asakusafw-compiler#106, we have been enhanced operator graph/planning models:
* `OperatorInput.getInputUnit()` returns the input granularity
  * `InputUnit.RECORD` - for *extract* kind operator inputs
  * `InputUnit.GROUP` - for *co-group* kind operator inputs
  * `InputUnit.WHOLE` - for broadcast inputs, **including views**
* `OperatorInput.getAttribute(ViewInfo.class)` returns the view style
  * `ViewInfo.getKind() == ViewKind.FLAT` - requires `View` (flat views)
  * `ViewInfo.getKind() == ViewKind.GROUP` - requires `GroupView` (group views)
  * `null` - not a view
* `BroadcastInfo` was also provided for views
  * for flat views - should be ignored
  * for group views - `BroadcastInfo.getFormatInfo()` contains partitioning information for the view

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#700
* asakusafw/asakusafw-compiler#106

## Wanted reviewer

* @akirakw - compilation will be failed until the above PRs were merged
* @ueshin 