### PR TITLE
Enable View API in Asakusa on Spark.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateClassBuilder.scala
@@ -52,7 +52,8 @@ import com.asakusafw.spark.tools.asm4s._
 abstract class AggregateClassBuilder(
   val valueType: Type,
   val combinerType: Type,
-  val operator: UserOperator)(
+  val operator: UserOperator,
+  mapSideCombine: Boolean)(
     val label: String,
     val subplanOutputs: Seq[SubPlan.Output])(
       implicit val context: NodeCompiler.Context)
@@ -131,6 +132,10 @@ abstract class AggregateClassBuilder(
 
   override def defMethods(methodDef: MethodDef): Unit = {
     super.defMethods(methodDef)
+
+    methodDef.newMethod("mapSideCombine", Type.BOOLEAN_TYPE, Seq.empty) { implicit mb =>
+      `return`(ldc(mapSideCombine))
+    }
 
     methodDef.newMethod(
       "fragments",

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateCompiler.scala
@@ -53,7 +53,9 @@ class AggregateCompiler extends NodeCompiler {
       new AggregateClassBuilder(
         valueType,
         combinerType,
-        operator)(
+        operator,
+        mapSideCombine =
+          subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
         subPlanInfo.getLabel,
         subplan.getOutputs.toSeq) with CacheOnce
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateCompiler.scala
@@ -46,11 +46,6 @@ class AggregateCompiler extends NodeCompiler {
       s"The primary operator should be user operator: ${primaryOperator} [${subplan}]")
     val operator = primaryOperator.asInstanceOf[UserOperator]
 
-    assert(operator.inputs.size == 1,
-      s"The size of inputs should be 1: ${operator.inputs.size} [${subplan}]")
-    assert(operator.outputs.size == 1,
-      s"The size of outputs should be 1: ${operator.outputs.size} [${subplan}]")
-
     val valueType = operator.inputs.head.dataModelType
     val combinerType = operator.outputs.head.dataModelType
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateInstantiator.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateInstantiator.scala
@@ -42,8 +42,6 @@ object AggregateInstantiator extends Instantiator {
     val primaryOperator =
       subplan.getAttribute(classOf[SubPlanInfo]).getPrimaryOperator.asInstanceOf[UserOperator]
 
-    assert(primaryOperator.inputs.size == 1,
-      s"The size of inputs should be 1: ${primaryOperator.inputs.size} [${subplan}]")
     val input = primaryOperator.inputs.head
 
     val aggregate = pushNew(nodeType)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/branching/Aggregations.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/branching/Aggregations.scala
@@ -32,7 +32,6 @@ import com.asakusafw.spark.runtime.rdd.{ BranchKey, ShuffleKey }
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.spark.tools.asm.MethodBuilder._
 import com.asakusafw.spark.tools.asm4s._
-import com.asakusafw.vocabulary.flow.processor.PartialAggregation
 
 trait Aggregations extends ClassBuilder {
 
@@ -78,11 +77,9 @@ trait Aggregations extends ClassBuilder {
             for {
               output <- subplanOutputs.sortBy(_.getOperator.getSerialNumber)
               outputInfo <- Option(output.getAttribute(classOf[SubPlanOutputInfo]))
-              if outputInfo.getAggregationInfo.isInstanceOf[UserOperator]
+              if outputInfo.getOutputType == SubPlanOutputInfo.OutputType.AGGREGATED
               operator = outputInfo.getAggregationInfo.asInstanceOf[UserOperator]
               if AggregationCompiler.support(operator)(context.aggregationCompilerContext)
-              if operator.annotationDesc.elements("partialAggregation").value !=
-                PartialAggregation.TOTAL
             } {
               val aggregationType =
                 AggregationClassBuilder.getOrCompile(operator)(context.aggregationCompilerContext)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/branching/Branching.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/branching/Branching.scala
@@ -25,7 +25,7 @@ trait Branching
   with BranchKeysField
   with PartitionersField
   with OrderingsField
-  with AggregationsField
+  with Aggregations
   with PreparingKey
   with Deserializer {
 
@@ -39,7 +39,7 @@ object Branching {
     with BranchKeysField.Context
     with PartitionersField.Context
     with OrderingsField.Context
-    with AggregationsField.Context
+    with Aggregations.Context
     with PreparingKey.Context
     with Deserializer.Context
 }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/EdgeFragmentClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/EdgeFragmentClassBuilder.scala
@@ -25,14 +25,13 @@ import org.objectweb.asm.signature.SignatureVisitor
 
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.spark.compiler.operator.EdgeFragmentClassBuilder._
-import com.asakusafw.spark.compiler.spi.OperatorCompiler
 import com.asakusafw.spark.runtime.fragment.{ EdgeFragment, Fragment }
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.spark.tools.asm.MethodBuilder._
 
 class EdgeFragmentClassBuilder(
   dataModelType: Type)(
-    implicit context: OperatorCompiler.Context)
+    implicit context: CompilerContext)
   extends ClassBuilder(
     Type.getType(
       s"L${GeneratedClassPackageInternalName}/${context.flowId}/fragment/EdgeFragment$$${nextId};"),
@@ -69,21 +68,21 @@ class EdgeFragmentClassBuilder(
 
 object EdgeFragmentClassBuilder {
 
-  private[this] val curIds: mutable.Map[OperatorCompiler.Context, AtomicLong] =
+  private[this] val curIds: mutable.Map[CompilerContext, AtomicLong] =
     mutable.WeakHashMap.empty
 
-  def nextId(implicit context: OperatorCompiler.Context): Long =
+  def nextId(implicit context: CompilerContext): Long =
     curIds.getOrElseUpdate(context, new AtomicLong(0L)).getAndIncrement()
 
-  private[this] val cache: mutable.Map[OperatorCompiler.Context, mutable.Map[(String, Type), Type]] = // scalastyle:ignore
+  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[Type, Type]] = // scalastyle:ignore
     mutable.WeakHashMap.empty
 
   def getOrCompile(
     dataModelType: Type)(
-      implicit context: OperatorCompiler.Context): Type = {
-    cache.getOrElseUpdate(context, mutable.Map.empty).getOrElseUpdate(
-      (context.flowId, dataModelType), {
-        context.addClass(new EdgeFragmentClassBuilder(dataModelType))
-      })
+      implicit context: CompilerContext): Type = {
+    cache.getOrElseUpdate(context, mutable.Map.empty)
+      .getOrElseUpdate(
+        dataModelType,
+        context.addClass(new EdgeFragmentClassBuilder(dataModelType)))
   }
 }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/MapGroupViewClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/MapGroupViewClassBuilder.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.spark.compiler
+package operator
+
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.collection.mutable
+
+import org.objectweb.asm.{ Opcodes, Type }
+import org.objectweb.asm.signature.SignatureVisitor
+
+import com.asakusafw.spark.compiler.operator.MapGroupViewClassBuilder._
+import com.asakusafw.spark.runtime.fragment.MapGroupView
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
+import com.asakusafw.spark.tools.asm._
+import com.asakusafw.spark.tools.asm.MethodBuilder._
+import com.asakusafw.spark.tools.asm4s._
+
+class MapGroupViewClassBuilder(
+  keyElementTypes: Seq[Type])(
+    implicit context: CompilerContext)
+  extends ClassBuilder(
+    Type.getType(
+      s"L${GeneratedClassPackageInternalName}/${context.flowId}/fragment/MapGroupView$$${nextId};"),
+    new ClassSignatureBuilder()
+      .newFormalTypeParameter("V", classOf[AnyRef].asType)
+      .newSuperclass {
+        _.newClassType(classOf[MapGroupView[_, _]].asType) {
+          _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[ShuffleKey].asType)
+            .newTypeArgument(SignatureVisitor.INSTANCEOF, "V")
+        }
+      },
+    classOf[MapGroupView[_, _]].asType) {
+
+  override def defConstructors(ctorDef: ConstructorDef): Unit = {
+    ctorDef.newInit(
+      Seq(classOf[Map[_, _]].asType),
+      new MethodSignatureBuilder()
+        .newParameterType {
+          _.newClassType(classOf[Map[_, _]].asType) {
+            _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[ShuffleKey].asType)
+              .newTypeArgument(SignatureVisitor.INSTANCEOF) {
+                _.newClassType(classOf[Seq[_]].asType) {
+                  _.newTypeArgument()
+                }
+              }
+          }
+        }
+        .newVoidReturnType()) { implicit mb =>
+        val thisVar :: mapVar :: _ = mb.argVars
+        thisVar.push().invokeInit(superType, mapVar.push())
+      }
+  }
+
+  override def defMethods(methodDef: MethodDef): Unit = {
+    super.defMethods(methodDef)
+
+    methodDef.newMethod(
+      Opcodes.ACC_PROTECTED,
+      "key",
+      classOf[AnyRef].asType,
+      Seq(classOf[Seq[AnyRef]].asType),
+      new MethodSignatureBuilder()
+        .newParameterType {
+          _.newClassType(classOf[Seq[_]].asType) {
+            _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[AnyRef].asType)
+          }
+        }
+        .newReturnType(classOf[AnyRef].asType)) { implicit mb =>
+        val thisVar :: elementsVar :: _ = mb.argVars
+        `return`(
+          thisVar.push().invokeV("key", classOf[ShuffleKey].asType, elementsVar.push()))
+      }
+
+    methodDef.newMethod(
+      Opcodes.ACC_PROTECTED,
+      "key",
+      classOf[ShuffleKey].asType,
+      Seq(classOf[Seq[AnyRef]].asType),
+      new MethodSignatureBuilder()
+        .newParameterType {
+          _.newClassType(classOf[Seq[_]].asType) {
+            _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[AnyRef].asType)
+          }
+        }
+        .newReturnType(classOf[ShuffleKey].asType)) { implicit mb =>
+        val thisVar :: elementsVar :: _ = mb.argVars
+
+        elementsVar.push().invokeI("size", Type.INT_TYPE).unlessEq(ldc(keyElementTypes.size)) {
+          `throw`(pushNewIAE(s"The number of key elements should be ${keyElementTypes.size}."))
+        }
+
+        keyElementTypes.zipWithIndex.foreach {
+          case (t, i) =>
+            applySeq(elementsVar.push(), ldc(i)).isInstanceOf(t).unlessTrue {
+              val className = t.getClassName
+              val idx = className.lastIndexOf('.')
+              val simpleName = if (idx >= 0) {
+                className.substring(idx + 1)
+              } else {
+                className
+              }
+              `throw`(pushNewIAE(s"The key elements(${i}) should be ${simpleName}."))
+            }
+        }
+
+        val shuffleKey = pushNew(classOf[ShuffleKey].asType)
+        shuffleKey.dup().invokeInit(
+          pushObject(WritableSerDe)
+            .invokeV("serialize", classOf[Array[Byte]].asType, elementsVar.push()))
+        `return`(shuffleKey)
+      }
+  }
+
+  private def pushNewIAE(message: String)(implicit mb: MethodBuilder): Stack = {
+    val ex = pushNew(classOf[IllegalArgumentException].asType)
+    ex.dup().invokeInit(ldc(message))
+    ex
+  }
+}
+
+object MapGroupViewClassBuilder {
+
+  private[this] val curIds: mutable.Map[CompilerContext, AtomicLong] =
+    mutable.WeakHashMap.empty
+
+  def nextId(implicit context: CompilerContext): Long =
+    curIds.getOrElseUpdate(context, new AtomicLong(0L)).getAndIncrement()
+
+  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[Seq[Type], Type]] = // scalastyle:ignore
+    mutable.WeakHashMap.empty
+
+  def getOrCompile(
+    keyElementTypes: Seq[Type])(
+      implicit context: CompilerContext): Type = {
+    cache.getOrElseUpdate(context, mutable.Map.empty)
+      .getOrElseUpdate(
+        keyElementTypes,
+        context.addClass(new MapGroupViewClassBuilder(keyElementTypes)))
+  }
+}

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/ViewFields.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/ViewFields.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.spark.compiler
+package operator
+
+import scala.collection.JavaConversions._
+
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
+import org.objectweb.asm.Opcodes
+
+import com.asakusafw.lang.compiler.model.graph.{ MarkerOperator, OperatorInput }
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.GroupView
+import com.asakusafw.spark.compiler.graph.BroadcastIds
+import com.asakusafw.spark.tools.asm._
+import com.asakusafw.spark.tools.asm.MethodBuilder._
+import com.asakusafw.spark.tools.asm4s._
+
+trait ViewFields extends ClassBuilder {
+
+  implicit def context: ViewFields.Context
+
+  def operatorInputs: Seq[OperatorInput]
+
+  lazy val viewInputs: Seq[OperatorInput] =
+    operatorInputs.filter(_.getInputUnit == OperatorInput.InputUnit.WHOLE)
+
+  override def defFields(fieldDef: FieldDef): Unit = {
+    super.defFields(fieldDef)
+
+    viewInputs.zipWithIndex.foreach {
+      case (input, i) =>
+        fieldDef.newField(
+          Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL,
+          s"view${i}",
+          classOf[GroupView[_]].asType)
+    }
+  }
+
+  def initViewFields(broadcastsVar: Var)(implicit mb: MethodBuilder): Unit = {
+    val thisVar :: _ = mb.argVars
+
+    viewInputs.zipWithIndex.foreach {
+      case (input, i) =>
+        val marker: Option[MarkerOperator] = {
+          val opposites = input.getOpposites
+          assert(opposites.size <= 1,
+            s"The size of broadcast inputs should be 0 or 1: ${opposites.size}")
+          opposites.headOption.map { opposite =>
+            val operator = opposite.getOwner
+            assert(operator.isInstanceOf[MarkerOperator],
+              s"The master input should be marker operator: ${operator} [${operator}]")
+            assert(
+              operator.asInstanceOf[MarkerOperator].getAttribute(classOf[PlanMarker])
+                == PlanMarker.BROADCAST,
+              s"The master input should be BROADCAST marker operator: ${
+                operator.asInstanceOf[MarkerOperator].getAttribute(classOf[PlanMarker])
+              } [${operator}]")
+            operator.asInstanceOf[MarkerOperator]
+          }
+        }
+
+        val keyElementTypes = input.dataModelRef.groupingTypes(input.getGroup.getGrouping)
+
+        val mapGroupViewType = MapGroupViewClassBuilder.getOrCompile(keyElementTypes)
+
+        thisVar.push().putField(
+          s"view${i}", {
+            val mapGroupView = pushNew(mapGroupViewType)
+            mapGroupView.dup().invokeInit(
+              marker.map { marker =>
+                applyMap(
+                  broadcastsVar.push(), context.broadcastIds.getField(marker))
+                  .cast(classOf[Broadcasted[_]].asType)
+                  .invokeV("value", classOf[AnyRef].asType)
+                  .cast(classOf[Map[_, _]].asType)
+              }.getOrElse {
+                buildMap(_ => ())
+              })
+            mapGroupView.asType(classOf[GroupView[_]].asType)
+          })
+    }
+  }
+
+  def getViewField(input: OperatorInput)(implicit mb: MethodBuilder): Stack = {
+    val thisVar :: _ = mb.argVars
+    val i = viewInputs.indexOf(input)
+    assert(i >= 0,
+      s"The input unit of ${input} is not InputUnit.WHOLE: ${input.getInputUnit}")
+    thisVar.push().getField(s"view${i}", classOf[GroupView[_]].asType)
+  }
+}
+
+object ViewFields {
+
+  trait Context
+    extends CompilerContext
+    with DataModelLoaderProvider {
+
+    def broadcastIds: BroadcastIds
+  }
+}

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/AggregationClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/AggregationClassBuilder.scala
@@ -52,8 +52,6 @@ abstract class AggregationClassBuilder(
   override def defMethods(methodDef: MethodDef): Unit = {
     super.defMethods(methodDef)
 
-    methodDef.newMethod("mapSideCombine", Type.BOOLEAN_TYPE, Seq.empty)(defMapSideCombine()(_))
-
     methodDef.newMethod("newCombiner", classOf[AnyRef].asType, Seq.empty) { implicit mb =>
       val thisVar :: _ = mb.argVars
       `return`(thisVar.push().invokeV("newCombiner", combinerType))
@@ -134,7 +132,6 @@ abstract class AggregationClassBuilder(
       }
   }
 
-  def defMapSideCombine()(implicit mb: MethodBuilder): Unit
   def defNewCombiner()(implicit mb: MethodBuilder): Unit
   def defInitCombinerByValue(combinerVar: Var, valueVar: Var)(implicit mb: MethodBuilder): Unit
   def defMergeValue(combinerVar: Var, valueVar: Var)(implicit mb: MethodBuilder): Unit

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/AggregationClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/AggregationClassBuilder.scala
@@ -35,7 +35,7 @@ abstract class AggregationClassBuilder(
   val valueType: Type,
   val combinerType: Type)(
     val aggregationType: AggregationType)(
-      implicit context: AggregationCompiler.Context)
+      implicit val context: AggregationCompiler.Context)
   extends ClassBuilder(
     Type.getType(
       s"L${GeneratedClassPackageInternalName}/${context.flowId}/fragment/${nextName(aggregationType)};"), // scalastyle:ignore

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/AggregationClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/AggregationClassBuilder.scala
@@ -164,7 +164,7 @@ object AggregationClassBuilder {
     }"
   }
 
-  private[this] val cache: mutable.Map[AggregationCompiler.Context, mutable.Map[(String, Long), Type]] = // scalastyle:ignore
+  private[this] val cache: mutable.Map[AggregationCompiler.Context, mutable.Map[Long, Type]] = // scalastyle:ignore
     mutable.WeakHashMap.empty
 
   def getOrCompile(
@@ -172,7 +172,7 @@ object AggregationClassBuilder {
       implicit context: AggregationCompiler.Context): Type = {
     cache.getOrElseUpdate(context, mutable.Map.empty)
       .getOrElseUpdate(
-        (context.flowId, operator.getOriginalSerialNumber),
+        operator.getOriginalSerialNumber,
         AggregationCompiler.compile(operator))
   }
 }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/FoldAggregationCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/FoldAggregationCompiler.scala
@@ -30,7 +30,6 @@ import com.asakusafw.spark.compiler.spi.AggregationCompiler
 import com.asakusafw.spark.runtime.graph.BroadcastId
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.spark.tools.asm.MethodBuilder._
-import com.asakusafw.vocabulary.flow.processor.PartialAggregation
 import com.asakusafw.vocabulary.operator.Fold
 
 class FoldAggregationCompiler extends AggregationCompiler {
@@ -121,13 +120,6 @@ private class FoldAggregationClassBuilder(
         initOperatorField()
         initViewFields(broadcastsVar)
       }
-  }
-
-  override def defMapSideCombine()(implicit mb: MethodBuilder): Unit = {
-    val partialAggregation =
-      operator.annotationDesc.elements("partialAggregation")
-        .value.asInstanceOf[PartialAggregation]
-    `return`(ldc(partialAggregation == PartialAggregation.PARTIAL))
   }
 
   override def defNewCombiner()(implicit mb: MethodBuilder): Unit = {

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompiler.scala
@@ -31,7 +31,6 @@ import com.asakusafw.spark.runtime.util.ValueOptionOps
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.spark.tools.asm.MethodBuilder._
 import com.asakusafw.spark.tools.asm4s._
-import com.asakusafw.vocabulary.flow.processor.PartialAggregation
 import com.asakusafw.vocabulary.operator.Summarize
 
 class SummarizeAggregationCompiler extends AggregationCompiler {
@@ -85,13 +84,6 @@ private class SummarizeAggregationClassBuilder(
         val thisVar :: _ = mb.argVars
         thisVar.push().invokeInit(superType)
       }
-  }
-
-  override def defMapSideCombine()(implicit mb: MethodBuilder): Unit = {
-    val partialAggregation =
-      operator.annotationDesc.elements("partialAggregation")
-        .value.asInstanceOf[PartialAggregation]
-    `return`(ldc(partialAggregation != PartialAggregation.TOTAL))
   }
 
   override def defNewCombiner()(implicit mb: MethodBuilder): Unit = {

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/core/CoreOperatorFragmentClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/core/CoreOperatorFragmentClassBuilder.scala
@@ -17,7 +17,7 @@ package com.asakusafw.spark.compiler
 package operator
 package core
 
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
@@ -38,12 +38,16 @@ abstract class CoreOperatorFragmentClassBuilder(
 
   override final def defConstructors(ctorDef: ConstructorDef): Unit = {
     ctorDef.newInit(
-      Seq(classOf[Map[BroadcastId, Broadcast[_]]].asType, classOf[Fragment[_]].asType),
+      Seq(classOf[Map[BroadcastId, Broadcasted[_]]].asType, classOf[Fragment[_]].asType),
       new MethodSignatureBuilder()
         .newParameterType {
           _.newClassType(classOf[Map[_, _]].asType) {
             _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[BroadcastId].asType)
-              .newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[Broadcast[_]].asType)
+              .newTypeArgument(SignatureVisitor.INSTANCEOF) {
+                _.newClassType(classOf[Broadcasted[_]].asType) {
+                  _.newTypeArgument()
+                }
+              }
           }
         }
         .newParameterType {

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/BranchOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/BranchOperatorCompiler.scala
@@ -87,6 +87,7 @@ private class BranchOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     operator.inputs(Branch.ID_INPUT).dataModelType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(
     Option(
       new ClassSignatureBuilder()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/BranchOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/BranchOperatorCompiler.scala
@@ -23,7 +23,8 @@ import scala.reflect.ClassTag
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
-import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.BranchOperatorFragment
@@ -49,8 +50,9 @@ class BranchOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 1, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 1: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 1,
+      "The size of inputs should be greater than or equals to 1: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size > 0,
       s"The size of outputs should be greater than 0: ${operator.outputs.size} [${operator}]")
 
@@ -63,7 +65,11 @@ class BranchOperatorCompiler extends UserOperatorCompiler {
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_.dataModelClass)
+        .zip(operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass))
         .forall {
           case (method, model) => method.isAssignableFrom(model)
@@ -71,7 +77,11 @@ class BranchOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_.dataModelClass)
+        (operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
 
@@ -160,13 +170,19 @@ private class BranchOperatorFragmentClassBuilder(
           .invokeV(
             operator.methodDesc.name,
             operator.methodDesc.asType.getReturnType,
-            dmVar.push().asType(operator.methodDesc.asType.getArgumentTypes()(0))
-              +: operator.arguments.map { argument =>
+            (dmVar.push()
+              +: operator.inputs.drop(1).collect {
+                case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+                  getViewField(input)
+              }
+              ++: operator.arguments.map { argument =>
                 Option(argument.value).map { value =>
                   ldc(value)(ClassTag(argument.resolveClass), implicitly)
                 }.getOrElse {
                   pushNull(argument.resolveClass.asType)
                 }
+              }).zip(operator.methodDesc.asType.getArgumentTypes()).map {
+                case (s, t) => s.asType(t)
               }: _*)
         branch.dup().unlessNotNull {
           `throw`(pushNew0(classOf[NullPointerException].asType))

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/CoGroupOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/CoGroupOperatorCompiler.scala
@@ -90,6 +90,7 @@ private class CoGroupOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     classOf[IndexedSeq[Iterator[_]]].asType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(
     None,
     classOf[CoGroupOperatorFragment].asType) {

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/CoGroupOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/CoGroupOperatorCompiler.scala
@@ -29,9 +29,10 @@ import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
 import com.asakusafw.lang.compiler.analyzer.util.GroupOperatorUtil
-import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
 import com.asakusafw.runtime.core.Result
 import com.asakusafw.runtime.flow.{ ArrayListBuffer, FileMapListBuffer, ListBuffer }
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user._
@@ -64,7 +65,13 @@ class CoGroupOperatorCompiler extends UserOperatorCompiler {
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_ => classOf[JList[_]])
+        .zip(operator.inputs.takeWhile(_.getInputUnit != OperatorInput.InputUnit.WHOLE)
+          .map(_ => classOf[JList[_]])
+          ++: operator.inputs.dropWhile(_.getInputUnit != OperatorInput.InputUnit.WHOLE)
+          .collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.outputs.map(_ => classOf[Result[_]])
           ++: operator.arguments.map(_.resolveClass))
         .forall {
@@ -73,7 +80,15 @@ class CoGroupOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_ => classOf[JList[_]])
+        (operator.inputs.takeWhile { input =>
+          input.getInputUnit != OperatorInput.InputUnit.WHOLE
+        }.map(_ => classOf[JList[_]])
+          ++: operator.inputs.dropWhile { input =>
+            input.getInputUnit != OperatorInput.InputUnit.WHOLE
+          }.collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.outputs.map(_ => classOf[Result[_]])
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
@@ -160,13 +175,17 @@ private class CoGroupOperatorFragmentClassBuilder(
         getOperatorField()
           .invokeV(
             operator.methodDesc.getName,
-            (0 until operator.inputs.size).map { i =>
-              applySeq(buffersVar.push(), ldc(i))
-                .cast(operator.methodDesc.asType.getArgumentTypes()(i))
-            }
+            (operator.inputs.takeWhile(_.getInputUnit != OperatorInput.InputUnit.WHOLE)
+              .zipWithIndex.map {
+                case (_, i) => applySeq(buffersVar.push(), ldc(i))
+              }
+              ++ operator.inputs.dropWhile(_.getInputUnit != OperatorInput.InputUnit.WHOLE)
+              .collect {
+                case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+                  getViewField(input)
+              }
               ++ (0 until operator.outputs.size).map { i =>
                 applySeq(outputsVar.push(), ldc(i))
-                  .cast(operator.methodDesc.asType.getArgumentTypes()(operator.inputs.size + i))
               }
               ++ operator.arguments.map { argument =>
                 Option(argument.value).map { value =>
@@ -174,6 +193,8 @@ private class CoGroupOperatorFragmentClassBuilder(
                 }.getOrElse {
                   pushNull(argument.resolveClass.asType)
                 }
+              }).zip(operator.methodDesc.asType.getArgumentTypes()).map {
+                case (s, t) => s.asType(t)
               }: _*)
 
         `return`()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ConvertOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ConvertOperatorCompiler.scala
@@ -78,6 +78,7 @@ private class ConvertOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     operator.inputs(Convert.ID_INPUT).dataModelType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(
     Option(
       new ClassSignatureBuilder()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ConvertOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ConvertOperatorCompiler.scala
@@ -22,7 +22,8 @@ import scala.reflect.ClassTag
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
-import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.ConvertOperatorFragment
@@ -47,14 +48,19 @@ class ConvertOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 1, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 1: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 1,
+      "The size of inputs should be greater than or equals to 1: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size == 2,
       s"The size of outputs should be 2: ${operator.outputs.size} [${operator}]")
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_.dataModelClass)
+        .zip(operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass))
         .forall {
           case (method, model) => method.isAssignableFrom(model)
@@ -62,7 +68,11 @@ class ConvertOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_.dataModelClass)
+        (operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
 
@@ -139,13 +149,19 @@ private class ConvertOperatorFragmentClassBuilder(
             .invokeV(
               operator.methodDesc.getName,
               operator.outputs(Convert.ID_OUTPUT_CONVERTED).dataModelType,
-              inputVar.push().asType(operator.methodDesc.asType.getArgumentTypes()(0))
-                +: operator.arguments.map { argument =>
+              (inputVar.push()
+                +: operator.inputs.drop(1).collect {
+                  case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE => // scalastyle:ignore
+                    getViewField(input)
+                }
+                ++: operator.arguments.map { argument =>
                   Option(argument.value).map { value =>
                     ldc(value)(ClassTag(argument.resolveClass), implicitly)
                   }.getOrElse {
                     pushNull(argument.resolveClass.asType)
                   }
+                }).zip(operator.methodDesc.asType.getArgumentTypes()).map {
+                  case (s, t) => s.asType(t)
                 }: _*))
       }
   }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ExtractOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ExtractOperatorCompiler.scala
@@ -22,8 +22,8 @@ import scala.reflect.ClassTag
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
-import com.asakusafw.lang.compiler.model.graph.UserOperator
-import com.asakusafw.runtime.core.Result
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
+import com.asakusafw.runtime.core.{ GroupView, Result }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.ExtractOperatorFragment
@@ -49,14 +49,19 @@ class ExtractOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 1, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 1: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 1,
+      "The size of inputs should be greater than or equals to 1: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size > 0,
       s"The size of outputs should be greater than 0: ${operator.outputs.size} [${operator}]")
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_.dataModelClass)
+        .zip(operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.outputs.map(_ => classOf[Result[_]])
           ++: operator.arguments.map(_.resolveClass))
         .forall {
@@ -65,7 +70,11 @@ class ExtractOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_.dataModelClass)
+        (operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.outputs.map(_ => classOf[Result[_]])
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
@@ -157,9 +166,13 @@ private class ExtractOperatorFragmentClassBuilder(
         getOperatorField()
           .invokeV(
             operator.methodDesc.getName,
-            inputVar.push().asType(operator.methodDesc.asType.getArgumentTypes()(0))
-              +: (0 until operator.outputs.size).map { i =>
-                applySeq(outputsVar.push(), ldc(i)).asType(classOf[Result[_]].asType)
+            (inputVar.push()
+              +: operator.inputs.drop(1).collect {
+                case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+                  getViewField(input)
+              }
+              ++: (0 until operator.outputs.size).map { i =>
+                applySeq(outputsVar.push(), ldc(i))
               }
               ++: operator.arguments.map { argument =>
                 Option(argument.value).map { value =>
@@ -167,6 +180,8 @@ private class ExtractOperatorFragmentClassBuilder(
                 }.getOrElse {
                   pushNull(argument.resolveClass.asType)
                 }
+              }).zip(operator.methodDesc.asType.getArgumentTypes()).map {
+                case (s, t) => s.asType(t)
               }: _*)
 
         `return`()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ExtractOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/ExtractOperatorCompiler.scala
@@ -82,6 +82,7 @@ private class ExtractOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     operator.inputs(Extract.ID_INPUT).dataModelType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(
     Option(
       new ClassSignatureBuilder()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompiler.scala
@@ -79,6 +79,7 @@ private class LoggingOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     operator.inputs(Logging.ID_INPUT).dataModelType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(
     Option(
       new ClassSignatureBuilder()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/SplitOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/SplitOperatorCompiler.scala
@@ -51,7 +51,7 @@ class SplitOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 1, // FIXME to take multiple inputs for side data?
+    assert(operator.inputs.size == 1,
       s"The size of inputs should be 1: ${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size == 2,
       s"The size of outputs should be 2: ${operator.outputs.size} [${operator}]")

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/SplitOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/SplitOperatorCompiler.scala
@@ -68,6 +68,7 @@ private class SplitOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     operator.inputs(Split.ID_INPUT).dataModelType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(
     Option(
       new ClassSignatureBuilder()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/UpdateOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/UpdateOperatorCompiler.scala
@@ -86,6 +86,7 @@ private class UpdateOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     operator.inputs(Update.ID_INPUT).dataModelType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(
     Option(
       new ClassSignatureBuilder()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/UpdateOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/UpdateOperatorCompiler.scala
@@ -22,7 +22,8 @@ import scala.reflect.ClassTag
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
-import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.UpdateOperatorFragment
@@ -47,8 +48,9 @@ class UpdateOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 1, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 1: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 1,
+      "The size of inputs should be greater than or equals to 1: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size == 1,
       s"The size of outputs should be 1: ${operator.outputs.size} [${operator}]")
 
@@ -62,7 +64,11 @@ class UpdateOperatorCompiler extends UserOperatorCompiler {
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_.dataModelClass)
+        .zip(operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass))
         .forall {
           case (method, model) => method.isAssignableFrom(model)
@@ -70,7 +76,11 @@ class UpdateOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_.dataModelClass)
+        (operator.inputs.take(1).map(_.dataModelClass)
+          ++: operator.inputs.drop(1).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
 
@@ -134,13 +144,19 @@ private class UpdateOperatorFragmentClassBuilder(
         getOperatorField()
           .invokeV(
             operator.methodDesc.getName,
-            inputVar.push().asType(operator.methodDesc.asType.getArgumentTypes()(0))
-              +: operator.arguments.map { argument =>
+            (inputVar.push()
+              +: operator.inputs.drop(1).collect {
+                case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+                  getViewField(input)
+              }
+              ++: operator.arguments.map { argument =>
                 Option(argument.value).map { value =>
                   ldc(value)(ClassTag(argument.resolveClass), implicitly)
                 }.getOrElse {
                   pushNull(argument.resolveClass.asType)
                 }
+              }).zip(operator.methodDesc.asType.getArgumentTypes()).map {
+                case (s, t) => s.asType(t)
               }: _*)
 
         `return`()

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompiler.scala
@@ -25,7 +25,6 @@ import org.objectweb.asm.signature.SignatureVisitor
 import com.asakusafw.lang.compiler.model.graph.UserOperator
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.join.BroadcastMasterBranchOperatorFragment
-import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.spark.tools.asm.MethodBuilder._
 import com.asakusafw.spark.tools.asm4s._
@@ -91,11 +90,10 @@ private class BroadcastMasterBranchOperatorFragmentClassBuilder(
     Option(
       new ClassSignatureBuilder()
         .newSuperclass {
-          _.newClassType(classOf[BroadcastMasterBranchOperatorFragment[_, _, _, _]].asType) {
-            _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[ShuffleKey].asType)
-              .newTypeArgument(
-                SignatureVisitor.INSTANCEOF,
-                operator.inputs(MasterBranchOp.ID_INPUT_MASTER).dataModelType)
+          _.newClassType(classOf[BroadcastMasterBranchOperatorFragment[_, _, _]].asType) {
+            _.newTypeArgument(
+              SignatureVisitor.INSTANCEOF,
+              operator.inputs(MasterBranchOp.ID_INPUT_MASTER).dataModelType)
               .newTypeArgument(
                 SignatureVisitor.INSTANCEOF,
                 operator.inputs(MasterBranchOp.ID_INPUT_TRANSACTION).dataModelType)
@@ -104,7 +102,7 @@ private class BroadcastMasterBranchOperatorFragmentClassBuilder(
                 operator.methodDesc.asType.getReturnType)
           }
         }),
-    classOf[BroadcastMasterBranchOperatorFragment[_, _, _, _]].asType)
+    classOf[BroadcastMasterBranchOperatorFragment[_, _, _]].asType)
   with BroadcastJoin
   with MasterBranch {
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompiler.scala
@@ -22,12 +22,14 @@ import scala.language.existentials
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
-import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.join.BroadcastMasterBranchOperatorFragment
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.spark.tools.asm.MethodBuilder._
 import com.asakusafw.spark.tools.asm4s._
+import com.asakusafw.vocabulary.attribute.ViewInfo
 import com.asakusafw.vocabulary.operator.{ MasterBranch => MasterBranchOp }
 
 class BroadcastMasterBranchOperatorCompiler extends UserOperatorCompiler {
@@ -47,8 +49,9 @@ class BroadcastMasterBranchOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 2, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 2: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 2,
+      "The size of inputs should be greater than or equals to 2: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size > 0,
       s"The size of outputs should be greater than 0: ${operator.outputs.size} [${operator}]")
 
@@ -61,7 +64,11 @@ class BroadcastMasterBranchOperatorCompiler extends UserOperatorCompiler {
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_.dataModelClass)
+        .zip(operator.inputs.take(2).map(_.dataModelClass)
+          ++: operator.inputs.drop(2).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass))
         .forall {
           case (method, model) => method.isAssignableFrom(model)
@@ -69,7 +76,11 @@ class BroadcastMasterBranchOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_.dataModelClass)
+        (operator.inputs.take(2).map(_.dataModelClass)
+          ++: operator.inputs.drop(2).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompiler.scala
@@ -81,7 +81,7 @@ class BroadcastMasterBranchOperatorCompiler extends UserOperatorCompiler {
 
 private class BroadcastMasterBranchOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     operator.inputs(MasterBranchOp.ID_INPUT_TRANSACTION).dataModelType,
     operator,
@@ -113,7 +113,6 @@ private class BroadcastMasterBranchOperatorFragmentClassBuilder(
 
     thisVar.push().invokeInit(
       superType,
-      masters(),
       buildMap { builder =>
         operatorOutputs.zip(fragmentVars).foreach {
           case (output, fragmentVar) =>

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompiler.scala
@@ -23,7 +23,6 @@ import org.objectweb.asm.signature.SignatureVisitor
 import com.asakusafw.lang.compiler.model.graph.UserOperator
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.join.BroadcastMasterCheckOperatorFragment
-import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.operator.{ MasterCheck => MasterCheckOp }
 
@@ -71,17 +70,16 @@ private class BroadcastMasterCheckOperatorFragmentClassBuilder(
     Option(
       new ClassSignatureBuilder()
         .newSuperclass {
-          _.newClassType(classOf[BroadcastMasterCheckOperatorFragment[_, _, _]].asType) {
-            _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[ShuffleKey].asType)
-              .newTypeArgument(
-                SignatureVisitor.INSTANCEOF,
-                operator.inputs(MasterCheckOp.ID_INPUT_MASTER).dataModelType)
+          _.newClassType(classOf[BroadcastMasterCheckOperatorFragment[_, _]].asType) {
+            _.newTypeArgument(
+              SignatureVisitor.INSTANCEOF,
+              operator.inputs(MasterCheckOp.ID_INPUT_MASTER).dataModelType)
               .newTypeArgument(
                 SignatureVisitor.INSTANCEOF,
                 operator.inputs(MasterCheckOp.ID_INPUT_TRANSACTION).dataModelType)
           }
         }),
-    classOf[BroadcastMasterCheckOperatorFragment[_, _, _]].asType)
+    classOf[BroadcastMasterCheckOperatorFragment[_, _]].asType)
   with BroadcastJoin
   with MasterCheck {
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompiler.scala
@@ -61,7 +61,7 @@ class BroadcastMasterCheckOperatorCompiler extends UserOperatorCompiler {
 
 private class BroadcastMasterCheckOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     operator.inputs(MasterCheckOp.ID_INPUT_TRANSACTION).dataModelType,
     operator,
@@ -88,7 +88,6 @@ private class BroadcastMasterCheckOperatorFragmentClassBuilder(
 
     thisVar.push().invokeInit(
       superType,
-      masters(),
       fragmentVars(MasterCheckOp.ID_OUTPUT_MISSED).push(),
       fragmentVars(MasterCheckOp.ID_OUTPUT_FOUND).push())
   }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompiler.scala
@@ -43,8 +43,9 @@ class BroadcastMasterCheckOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 2, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 2: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 2,
+      "The size of inputs should be greater than or equals to 2: " +
+        s"${operator.inputs.size} [${operator}]")
 
     assert(
       operator.outputs.forall(output =>

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompiler.scala
@@ -45,10 +45,11 @@ class BroadcastMasterJoinOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 2, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 2: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 2,
+      "The size of inputs should be greater than or equals to 2: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size == 2,
-      s"The size of outputs should be greater than 2: ${operator.outputs.size} [${operator}]")
+      s"The size of outputs should be 2: ${operator.outputs.size} [${operator}]")
 
     assert(operator.outputs(MasterJoinOp.ID_OUTPUT_MISSED).dataModelType
       == operator.inputs(MasterJoinOp.ID_INPUT_TRANSACTION).dataModelType,

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompiler.scala
@@ -24,7 +24,6 @@ import com.asakusafw.lang.compiler.model.graph.UserOperator
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.join.BroadcastMasterJoinOperatorFragment
-import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.spark.tools.asm.MethodBuilder._
 import com.asakusafw.vocabulary.operator.{ MasterJoin => MasterJoinOp }
@@ -74,11 +73,10 @@ private class BroadcastMasterJoinOperatorFragmentClassBuilder(
     Option(
       new ClassSignatureBuilder()
         .newSuperclass {
-          _.newClassType(classOf[BroadcastMasterJoinOperatorFragment[_, _, _, _]].asType) {
-            _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[ShuffleKey].asType)
-              .newTypeArgument(
-                SignatureVisitor.INSTANCEOF,
-                operator.inputs(MasterJoinOp.ID_INPUT_MASTER).dataModelType)
+          _.newClassType(classOf[BroadcastMasterJoinOperatorFragment[_, _, _]].asType) {
+            _.newTypeArgument(
+              SignatureVisitor.INSTANCEOF,
+              operator.inputs(MasterJoinOp.ID_INPUT_MASTER).dataModelType)
               .newTypeArgument(
                 SignatureVisitor.INSTANCEOF,
                 operator.inputs(MasterJoinOp.ID_INPUT_TRANSACTION).dataModelType)
@@ -87,7 +85,7 @@ private class BroadcastMasterJoinOperatorFragmentClassBuilder(
                 operator.outputs(MasterJoinOp.ID_OUTPUT_JOINED).dataModelType)
           }
         }),
-    classOf[BroadcastMasterJoinOperatorFragment[_, _, _, _]].asType)
+    classOf[BroadcastMasterJoinOperatorFragment[_, _, _]].asType)
   with BroadcastJoin
   with MasterJoin {
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompiler.scala
@@ -64,7 +64,7 @@ class BroadcastMasterJoinOperatorCompiler extends UserOperatorCompiler {
 
 private class BroadcastMasterJoinOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     operator.inputs(MasterJoinOp.ID_INPUT_TRANSACTION).dataModelType,
     operator,
@@ -94,7 +94,6 @@ private class BroadcastMasterJoinOperatorFragmentClassBuilder(
 
     thisVar.push().invokeInit(
       superType,
-      masters(),
       fragmentVars(MasterJoinOp.ID_OUTPUT_MISSED).push(),
       fragmentVars(MasterJoinOp.ID_OUTPUT_JOINED).push(),
       pushNew0(joinedType).asType(classOf[DataModel[_]].asType))

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompiler.scala
@@ -78,7 +78,7 @@ class BroadcastMasterJoinUpdateOperatorCompiler extends UserOperatorCompiler {
 
 private class BroadcastMasterJoinUpdateOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     operator.inputs(MasterJoinUpdateOp.ID_INPUT_TRANSACTION).dataModelType,
     operator,
@@ -105,7 +105,6 @@ private class BroadcastMasterJoinUpdateOperatorFragmentClassBuilder(
 
     thisVar.push().invokeInit(
       superType,
-      masters(),
       fragmentVars(MasterJoinUpdateOp.ID_OUTPUT_MISSED).push(),
       fragmentVars(MasterJoinUpdateOp.ID_OUTPUT_UPDATED).push())
   }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompiler.scala
@@ -20,7 +20,8 @@ package join
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
-import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.join.BroadcastMasterJoinUpdateOperatorFragment
 import com.asakusafw.spark.tools.asm._
@@ -43,8 +44,9 @@ class BroadcastMasterJoinUpdateOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 2, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 2: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 2,
+      "The size of inputs should be greater than or equals to 2: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size == 2,
       s"The size of outputs should be 2: ${operator.outputs.size} [${operator}]")
 
@@ -58,7 +60,11 @@ class BroadcastMasterJoinUpdateOperatorCompiler extends UserOperatorCompiler {
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_.dataModelClass)
+        .zip(operator.inputs.take(2).map(_.dataModelClass)
+          ++: operator.inputs.drop(2).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass))
         .forall {
           case (method, model) => method.isAssignableFrom(model)
@@ -66,7 +72,11 @@ class BroadcastMasterJoinUpdateOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_.dataModelClass)
+        (operator.inputs.take(2).map(_.dataModelClass)
+          ++: operator.inputs.drop(2).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompiler.scala
@@ -23,7 +23,6 @@ import org.objectweb.asm.signature.SignatureVisitor
 import com.asakusafw.lang.compiler.model.graph.UserOperator
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.join.BroadcastMasterJoinUpdateOperatorFragment
-import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.operator.{ MasterJoinUpdate => MasterJoinUpdateOp }
 
@@ -88,17 +87,16 @@ private class BroadcastMasterJoinUpdateOperatorFragmentClassBuilder(
     Option(
       new ClassSignatureBuilder()
         .newSuperclass {
-          _.newClassType(classOf[BroadcastMasterJoinUpdateOperatorFragment[_, _, _]].asType) {
-            _.newTypeArgument(SignatureVisitor.INSTANCEOF, classOf[ShuffleKey].asType)
-              .newTypeArgument(
-                SignatureVisitor.INSTANCEOF,
-                operator.inputs(MasterJoinUpdateOp.ID_INPUT_MASTER).dataModelType)
+          _.newClassType(classOf[BroadcastMasterJoinUpdateOperatorFragment[_, _]].asType) {
+            _.newTypeArgument(
+              SignatureVisitor.INSTANCEOF,
+              operator.inputs(MasterJoinUpdateOp.ID_INPUT_MASTER).dataModelType)
               .newTypeArgument(
                 SignatureVisitor.INSTANCEOF,
                 operator.inputs(MasterJoinUpdateOp.ID_INPUT_TRANSACTION).dataModelType)
           }
         }),
-    classOf[BroadcastMasterJoinUpdateOperatorFragment[_, _, _]].asType)
+    classOf[BroadcastMasterJoinUpdateOperatorFragment[_, _]].asType)
   with BroadcastJoin
   with MasterJoinUpdate {
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/JoinOperatorFragmentClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/JoinOperatorFragmentClassBuilder.scala
@@ -44,6 +44,7 @@ abstract class JoinOperatorFragmentClassBuilder(
   extends UserOperatorFragmentClassBuilder(
     dataModelType,
     operator.implementationClass.asType,
+    operator.inputs,
     operator.outputs)(signature, superType) {
 
   val masterType: Type = masterInput.dataModelType

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/JoinOperatorFragmentClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/JoinOperatorFragmentClassBuilder.scala
@@ -106,9 +106,13 @@ abstract class JoinOperatorFragmentClassBuilder(
                 .invokeV(
                   name,
                   t.getReturnType(),
-                  ({ () => mastersVar.push() } +:
-                    { () => txVar.push() } +:
-                    operator.arguments.map { argument =>
+                  ({ () => mastersVar.push() }
+                    +: { () => txVar.push() }
+                    +: operator.inputs.drop(2).collect {
+                      case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE => // scalastyle:ignore
+                        () => getViewField(input)
+                    }
+                    ++: operator.arguments.map { argument =>
                       Option(argument.value).map { value =>
                         () => ldc(value)(ClassTag(argument.resolveClass), implicitly)
                       }.getOrElse {

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterBranchOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterBranchOperatorCompiler.scala
@@ -81,7 +81,7 @@ class ShuffledMasterBranchOperatorCompiler extends UserOperatorCompiler {
 
 private class ShuffledMasterBranchOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     classOf[IndexedSeq[Iterator[_]]].asType,
     operator,

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterBranchOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterBranchOperatorCompiler.scala
@@ -22,7 +22,8 @@ import scala.language.existentials
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
 
-import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.lang.compiler.model.graph.{ OperatorInput, UserOperator }
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.user.join.ShuffledMasterBranchOperatorFragment
 import com.asakusafw.spark.tools.asm._
@@ -47,8 +48,9 @@ class ShuffledMasterBranchOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 2, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 2: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 2,
+      "The size of inputs should be greater than or equals to 2: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size > 0,
       s"The size of outputs should be greater than 0: ${operator.outputs.size} [${operator}]")
 
@@ -61,7 +63,11 @@ class ShuffledMasterBranchOperatorCompiler extends UserOperatorCompiler {
 
     assert(
       operator.methodDesc.parameterClasses
-        .zip(operator.inputs.map(_.dataModelClass)
+        .zip(operator.inputs.take(2).map(_.dataModelClass)
+          ++: operator.inputs.drop(2).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass))
         .forall {
           case (method, model) => method.isAssignableFrom(model)
@@ -69,7 +75,11 @@ class ShuffledMasterBranchOperatorCompiler extends UserOperatorCompiler {
       s"The operator method parameter types are not compatible: (${
         operator.methodDesc.parameterClasses.map(_.getName).mkString("(", ",", ")")
       }, ${
-        (operator.inputs.map(_.dataModelClass)
+        (operator.inputs.take(2).map(_.dataModelClass)
+          ++: operator.inputs.drop(2).collect {
+            case input: OperatorInput if input.getInputUnit == OperatorInput.InputUnit.WHOLE =>
+              classOf[GroupView[_]]
+          }
           ++: operator.arguments.map(_.resolveClass)).map(_.getName).mkString("(", ",", ")")
       }) [${operator}]")
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterCheckOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterCheckOperatorCompiler.scala
@@ -43,8 +43,9 @@ class ShuffledMasterCheckOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 2, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 2: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 2,
+      "The size of inputs should be greater than or equals to 2: " +
+        s"${operator.inputs.size} [${operator}]")
 
     assert(
       operator.outputs.forall(output =>

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterCheckOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterCheckOperatorCompiler.scala
@@ -61,7 +61,7 @@ class ShuffledMasterCheckOperatorCompiler extends UserOperatorCompiler {
 
 private class ShuffledMasterCheckOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     classOf[IndexedSeq[Iterator[_]]].asType,
     operator,

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinOperatorCompiler.scala
@@ -45,10 +45,11 @@ class ShuffledMasterJoinOperatorCompiler extends UserOperatorCompiler {
     assert(support(operator),
       s"The operator type is not supported: ${operator.annotationDesc.resolveClass.getSimpleName}"
         + s" [${operator}]")
-    assert(operator.inputs.size == 2, // FIXME to take multiple inputs for side data?
-      s"The size of inputs should be 2: ${operator.inputs.size} [${operator}]")
+    assert(operator.inputs.size >= 2,
+      "The size of inputs should be greater than or equals to 2: " +
+        s"${operator.inputs.size} [${operator}]")
     assert(operator.outputs.size == 2,
-      s"The size of outputs should be greater than 2: ${operator.outputs.size} [${operator}]")
+      s"The size of outputs should be 2: ${operator.outputs.size} [${operator}]")
 
     assert(operator.outputs(MasterJoinOp.ID_OUTPUT_MISSED).dataModelType
       == operator.inputs(MasterJoinOp.ID_INPUT_TRANSACTION).dataModelType,

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinOperatorCompiler.scala
@@ -64,7 +64,7 @@ class ShuffledMasterJoinOperatorCompiler extends UserOperatorCompiler {
 
 private class ShuffledMasterJoinOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     classOf[IndexedSeq[Iterator[_]]].asType,
     operator,

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinUpdateOperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinUpdateOperatorCompiler.scala
@@ -78,7 +78,7 @@ class ShuffledMasterJoinUpdateOperatorCompiler extends UserOperatorCompiler {
 
 private class ShuffledMasterJoinUpdateOperatorFragmentClassBuilder(
   operator: UserOperator)(
-    implicit val context: OperatorCompiler.Context)
+    implicit context: OperatorCompiler.Context)
   extends JoinOperatorFragmentClassBuilder(
     classOf[IndexedSeq[Iterator[_]]].asType,
     operator,

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/ordering/GroupingOrderingClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/ordering/GroupingOrderingClassBuilder.scala
@@ -125,15 +125,15 @@ object GroupingOrderingClassBuilder {
   def nextId(implicit context: CompilerContext): Long =
     curIds.getOrElseUpdate(context, new AtomicLong(0L)).getAndIncrement()
 
-  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[(String, Seq[Type]), Type]] =
+  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[Seq[Type], Type]] =
     mutable.WeakHashMap.empty
 
   def getOrCompile(
     groupingTypes: Seq[Type])(
       implicit context: CompilerContext): Type = {
-    cache.getOrElseUpdate(context, mutable.Map.empty).getOrElseUpdate(
-      (context.flowId, groupingTypes), {
-        context.addClass(new GroupingOrderingClassBuilder(groupingTypes))
-      })
+    cache.getOrElseUpdate(context, mutable.Map.empty)
+      .getOrElseUpdate(
+        groupingTypes,
+        context.addClass(new GroupingOrderingClassBuilder(groupingTypes)))
   }
 }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/ordering/SortOrderingClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/ordering/SortOrderingClassBuilder.scala
@@ -118,7 +118,7 @@ object SortOrderingClassBuilder {
   def nextId(implicit context: CompilerContext): Long =
     curIds.getOrElseUpdate(context, new AtomicLong(0L)).getAndIncrement()
 
-  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[(String, Type, Seq[(Type, Boolean)]), Type]] = // scalastyle:ignore
+  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[(Type, Seq[(Type, Boolean)]), Type]] = // scalastyle:ignore
     mutable.WeakHashMap.empty
 
   def getOrCompile(
@@ -137,11 +137,10 @@ object SortOrderingClassBuilder {
     if (orderingTypes.isEmpty) {
       groupingOrderingType
     } else {
-      cache.getOrElseUpdate(context, mutable.Map.empty).getOrElseUpdate(
-        (context.flowId, groupingOrderingType, orderingTypes), {
-          context.addClass(
-            new SortOrderingClassBuilder(groupingOrderingType, orderingTypes))
-        })
+      cache.getOrElseUpdate(context, mutable.Map.empty)
+        .getOrElseUpdate(
+          (groupingOrderingType, orderingTypes),
+          context.addClass(new SortOrderingClassBuilder(groupingOrderingType, orderingTypes)))
     }
   }
 }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/serializer/WritableSerializerClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/serializer/WritableSerializerClassBuilder.scala
@@ -66,15 +66,15 @@ object WritableSerializerClassBuilder {
   def nextId(implicit context: CompilerContext): Long =
     curIds.getOrElseUpdate(context, new AtomicLong(0L)).getAndIncrement()
 
-  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[(String, Type), Type]] =
+  private[this] val cache: mutable.Map[CompilerContext, mutable.Map[Type, Type]] =
     mutable.WeakHashMap.empty
 
   def getOrCompile(
     writableType: Type)(
       implicit context: CompilerContext): Type = {
-    cache.getOrElseUpdate(context, mutable.Map.empty).getOrElseUpdate(
-      (context.flowId, writableType), {
-        context.addClass(new WritableSerializerClassBuilder(writableType))
-      })
+    cache.getOrElseUpdate(context, mutable.Map.empty)
+      .getOrElseUpdate(
+        writableType,
+        context.addClass(new WritableSerializerClassBuilder(writableType)))
   }
 }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/spi/AggregationCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/spi/AggregationCompiler.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConversions._
 import org.objectweb.asm.Type
 
 import com.asakusafw.lang.compiler.model.graph.{ Operator, UserOperator }
+import com.asakusafw.spark.compiler.operator.ViewFields
 import com.asakusafw.spark.tools.asm.ClassBuilder
 
 trait AggregationCompiler {
@@ -40,6 +41,7 @@ object AggregationCompiler {
     extends CompilerContext
     with ClassLoaderProvider
     with DataModelLoaderProvider
+    with ViewFields.Context
 
   private def getCompiler(
     operator: Operator)(

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/spi/OperatorCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/spi/OperatorCompiler.scala
@@ -25,6 +25,7 @@ import org.objectweb.asm.Type
 
 import com.asakusafw.lang.compiler.model.graph.Operator
 import com.asakusafw.spark.compiler.graph.{ BranchKeys, BroadcastIds }
+import com.asakusafw.spark.compiler.operator.ViewFields
 import com.asakusafw.spark.tools.asm.ClassBuilder
 
 sealed trait OperatorType
@@ -54,7 +55,8 @@ object OperatorCompiler {
   trait Context
     extends CompilerContext
     with ClassLoaderProvider
-    with DataModelLoaderProvider {
+    with DataModelLoaderProvider
+    with ViewFields.Context {
 
     def branchKeys: BranchKeys
     def broadcastIds: BroadcastIds

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/MockCompilerContext.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/MockCompilerContext.scala
@@ -175,5 +175,7 @@ object MockCompilerContext {
 
     override val classLoader: ClassLoader = cl
     override val dataModelLoader: DataModelLoader = new MockDataModelLoader(cl)
+
+    override val broadcastIds: BroadcastIdsClassBuilder = new BroadcastIdsClassBuilder(flowId)
   }
 }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/FoldAggregationCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/FoldAggregationCompilerSpec.scala
@@ -73,7 +73,6 @@ class FoldAggregationCompilerSpec extends FlatSpec with UsingCompilerContext {
         .getConstructor(
           classOf[Map[BroadcastId, Broadcasted[_]]])
         .newInstance(Map.empty)
-      assert(aggregation.mapSideCombine === true)
 
       val valueCombiner = aggregation.valueCombiner()
       valueCombiner.insertAll((0 until 100).map { i =>
@@ -116,7 +115,6 @@ class FoldAggregationCompilerSpec extends FlatSpec with UsingCompilerContext {
       .getConstructor(
         classOf[Map[BroadcastId, Broadcasted[_]]])
       .newInstance(Map.empty)
-    assert(aggregation.mapSideCombine === true)
 
     val valueCombiner = aggregation.valueCombiner()
     valueCombiner.insertAll((0 until 100).map { i =>
@@ -199,7 +197,6 @@ class FoldAggregationCompilerSpec extends FlatSpec with UsingCompilerContext {
         Map(
           getBroadcastId(vMarker) -> view,
           getBroadcastId(gvMarker) -> groupview))
-    assert(aggregation.mapSideCombine === false)
 
     val valueCombiner = aggregation.combinerCombiner()
     valueCombiner.insertAll((0 until 100).map { i =>
@@ -251,7 +248,7 @@ object FoldAggregationCompilerSpec {
 
   class FoldOperator {
 
-    @Fold(partialAggregation = PartialAggregation.PARTIAL)
+    @Fold
     def fold(acc: Foo, value: Foo, n: Int, s: String): Unit = {
       acc.i.add(value.i)
       acc.i.add(n)
@@ -260,7 +257,7 @@ object FoldAggregationCompilerSpec {
       }
     }
 
-    @Fold(partialAggregation = PartialAggregation.PARTIAL)
+    @Fold
     def foldp[F <: FooP](acc: F, value: F, n: Int): Unit = {
       acc.getIOption.add(value.getIOption)
       acc.getIOption.add(n)

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/FoldAggregationCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/FoldAggregationCompilerSpec.scala
@@ -20,14 +20,25 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
+import java.util.function.Consumer
+
 import scala.collection.JavaConversions._
 
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
+
 import com.asakusafw.lang.compiler.model.description.{ ClassDescription, ImmediateDescription }
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.{ IntOption, StringOption }
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.AggregationCompiler
 import com.asakusafw.spark.runtime.aggregation.Aggregation
+import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.flow.processor.PartialAggregation
 import com.asakusafw.vocabulary.operator.Fold
@@ -58,7 +69,10 @@ class FoldAggregationCompilerSpec extends FlatSpec with UsingCompilerContext {
       val thisType = AggregationCompiler.compile(operator)
       val cls = context.loadClass[Aggregation[Seq[_], Foo, Foo]](thisType.getClassName)
 
-      val aggregation = cls.newInstance()
+      val aggregation = cls
+        .getConstructor(
+          classOf[Map[BroadcastId, Broadcasted[_]]])
+        .newInstance(Map.empty)
       assert(aggregation.mapSideCombine === true)
 
       val valueCombiner = aggregation.valueCombiner()
@@ -98,10 +112,96 @@ class FoldAggregationCompilerSpec extends FlatSpec with UsingCompilerContext {
     val thisType = AggregationCompiler.compile(operator)
     val cls = context.loadClass[Aggregation[Seq[_], Foo, Foo]](thisType.getClassName)
 
-    val aggregation = cls.newInstance()
+    val aggregation = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]])
+      .newInstance(Map.empty)
     assert(aggregation.mapSideCombine === true)
 
     val valueCombiner = aggregation.valueCombiner()
+    valueCombiner.insertAll((0 until 100).map { i =>
+      val foo = new Foo()
+      foo.i.modify(i)
+      (Seq(i % 2), foo)
+    }.iterator)
+    assert(valueCombiner.toSeq.map { case (k, v) => k -> (v.i.get, v.s.or("")) }
+      === Seq(
+        (Seq(0), ((0 until 100 by 2).sum + 10 * 49, "")),
+        (Seq(1), ((1 until 100 by 2).sum + 10 * 49, ""))))
+
+    val combinerCombiner = aggregation.combinerCombiner()
+    combinerCombiner.insertAll((0 until 100).map { i =>
+      val foo = new Foo()
+      foo.i.modify(i)
+      (Seq(i % 2), foo)
+    }.iterator)
+    assert(combinerCombiner.toSeq.map { case (k, v) => k -> (v.i.get, v.s.or("")) }
+      === Seq(
+        (Seq(0), ((0 until 100 by 2).sum + 10 * 49, "")),
+        (Seq(1), ((1 until 100 by 2).sum + 10 * 49, ""))))
+  }
+
+  it should "compile Aggregation for Fold with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[Fold], classOf[FoldOperator], "foldWithView")
+      .input("input", ClassDescription.of(classOf[Foo]))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("i"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("output", ClassDescription.of(classOf[Foo]))
+      .argument("n", ImmediateDescription.of(10))
+      .build()
+
+    implicit val context = newAggregationCompilerContext("flowId")
+
+    val thisType = AggregationCompiler.compile(operator)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Aggregation[Seq[_], Foo, Foo]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.i.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.i)) -> Seq(foo)
+      }.toMap)
+
+    val aggregation = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]])
+      .newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview))
+    assert(aggregation.mapSideCombine === false)
+
+    val valueCombiner = aggregation.combinerCombiner()
     valueCombiner.insertAll((0 until 100).map { i =>
       val foo = new Foo()
       foo.i.modify(i)
@@ -164,6 +264,12 @@ object FoldAggregationCompilerSpec {
     def foldp[F <: FooP](acc: F, value: F, n: Int): Unit = {
       acc.getIOption.add(value.getIOption)
       acc.getIOption.add(n)
+    }
+
+    @Fold
+    def foldWithView(acc: Foo, value: Foo, v: View[Foo], gv: GroupView[Foo], n: Int): Unit = {
+      acc.i.add(value.i)
+      acc.i.add(n)
     }
   }
 }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompilerSpec.scala
@@ -61,7 +61,6 @@ class SummarizeAggregationCompilerSpec extends FlatSpec with UsingCompilerContex
       .getConstructor(
         classOf[Map[BroadcastId, Broadcasted[_]]])
       .newInstance(Map.empty)
-    assert(aggregation.mapSideCombine === true)
 
     val valueCombiner = aggregation.valueCombiner()
     valueCombiner.insertAll((0 until 100).map { i =>
@@ -738,7 +737,7 @@ object SummarizeAggregationCompilerSpec {
 
   abstract class SummarizeOperator {
 
-    @Summarize(partialAggregation = PartialAggregation.PARTIAL)
+    @Summarize
     def summarize(value: Value): SummarizedValue
   }
 }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompilerSpec.scala
@@ -22,12 +22,15 @@ import org.scalatest.junit.JUnitRunner
 
 import scala.collection.JavaConversions._
 
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
+
 import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value._
 import com.asakusafw.spark.compiler.spi.AggregationCompiler
 import com.asakusafw.spark.runtime.aggregation.Aggregation
+import com.asakusafw.spark.runtime.graph.BroadcastId
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.flow.processor.PartialAggregation
 import com.asakusafw.vocabulary.model.{ Key, Summarized }
@@ -54,7 +57,10 @@ class SummarizeAggregationCompilerSpec extends FlatSpec with UsingCompilerContex
     val thisType = AggregationCompiler.compile(operator)
     val cls = context.loadClass[Aggregation[Seq[_], Value, SummarizedValue]](thisType.getClassName)
 
-    val aggregation = cls.newInstance()
+    val aggregation = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]])
+      .newInstance(Map.empty)
     assert(aggregation.mapSideCombine === true)
 
     val valueCombiner = aggregation.valueCombiner()

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/CoGroupOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/CoGroupOperatorCompilerSpec.scala
@@ -25,22 +25,27 @@ import java.util.function.Consumer
 import java.io.{ DataInput, DataOutput }
 import java.lang.{ Iterable => JIterable }
 import java.util.{ List => JList }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.{ ClassDescription, ImmediateDescription }
-import com.asakusafw.lang.compiler.model.graph.Groups
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.graph.Operator.InputOptionBuilder
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
-import com.asakusafw.runtime.core.Result
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, Result, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.{ IntOption, StringOption }
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.{ Fragment, GenericOutputFragment }
 import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.attribute.BufferType
 import com.asakusafw.vocabulary.operator.CoGroup
@@ -87,7 +92,7 @@ class CoGroupOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
       val nResult = new GenericOutputFragment[N]()
 
       val fragment = cls.getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]],
         classOf[Fragment[_]], classOf[Fragment[_]],
         classOf[Fragment[_]])
@@ -236,7 +241,7 @@ class CoGroupOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
     val nResult = new GenericOutputFragment[N]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]],
       classOf[Fragment[_]], classOf[Fragment[_]],
       classOf[Fragment[_]])
@@ -380,7 +385,7 @@ class CoGroupOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
       val nResult = new GenericOutputFragment[N]()
 
       val fragment = cls.getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]],
         classOf[Fragment[_]], classOf[Fragment[_]],
         classOf[Fragment[_]])
@@ -478,6 +483,176 @@ class CoGroupOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
       assert(barError.iterator.size === 0)
       assert(nResult.iterator.size === 0)
     }
+  }
+
+  it should "compile CoGroup operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[CoGroup], classOf[CoGroupOperator], "cogroupWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        Groups.parse(Seq("id")))
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("fooResult", ClassDescription.of(classOf[Foo]))
+      .output("barResult", ClassDescription.of(classOf[Bar]))
+      .output("fooError", ClassDescription.of(classOf[Foo]))
+      .output("barError", ClassDescription.of(classOf[Bar]))
+      .output("nResult", ClassDescription.of(classOf[N]))
+      .argument("n", ImmediateDescription.of(10))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.CoGroupType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[IndexedSeq[Iterator[_]]]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val fooResult = new GenericOutputFragment[Foo]()
+    val fooError = new GenericOutputFragment[Foo]()
+
+    val barResult = new GenericOutputFragment[Bar]()
+    val barError = new GenericOutputFragment[Bar]()
+
+    val nResult = new GenericOutputFragment[N]()
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    val fragment = cls.getConstructor(
+      classOf[Map[BroadcastId, Broadcasted[_]]],
+      classOf[Fragment[_]], classOf[Fragment[_]],
+      classOf[Fragment[_]], classOf[Fragment[_]],
+      classOf[Fragment[_]])
+      .newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview),
+        fooResult, barResult, fooError, barError, nResult)
+
+    {
+      fragment.reset()
+      val foos = Seq.empty[Foo]
+      val bars = Seq.empty[Bar]
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      assert(fooResult.iterator.size === 0)
+      assert(barResult.iterator.size === 0)
+      assert(fooError.iterator.size === 0)
+      assert(barError.iterator.size === 0)
+      val nResults = nResult.iterator.toSeq
+      assert(nResults.size === 1)
+      assert(nResults.head.n.get === 10)
+    }
+
+    fragment.reset()
+    assert(fooResult.iterator.size === 0)
+    assert(barResult.iterator.size === 0)
+    assert(fooError.iterator.size === 0)
+    assert(barError.iterator.size === 0)
+    assert(nResult.iterator.size === 0)
+
+    {
+      fragment.reset()
+      val foo = new Foo()
+      foo.id.modify(1)
+      val foos = Seq(foo)
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      val bars = Seq(bar)
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val fooResults = fooResult.iterator.toSeq
+      assert(fooResults.size === 1)
+      assert(fooResults.head.id.get === foo.id.get)
+      val barResults = barResult.iterator.toSeq
+      assert(barResults.size === 1)
+      assert(barResults.head.id.get === bar.id.get)
+      assert(barResults.head.fooId.get === bar.fooId.get)
+      val fooErrors = fooError.iterator.toSeq
+      assert(fooErrors.size === 0)
+      val barErrors = barError.iterator.toSeq
+      assert(barErrors.size === 0)
+      val nResults = nResult.iterator.toSeq
+      assert(nResults.size === 1)
+      assert(nResults.head.n.get === 10)
+    }
+
+    fragment.reset()
+    assert(fooResult.iterator.size === 0)
+    assert(barResult.iterator.size === 0)
+    assert(fooError.iterator.size === 0)
+    assert(barError.iterator.size === 0)
+    assert(nResult.iterator.size === 0)
+
+    {
+      fragment.reset()
+      val foo = new Foo()
+      foo.id.modify(1)
+      val foos = Seq(foo)
+      val bars = (0 until 10).map { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(1)
+        bar
+      }
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val fooResults = fooResult.iterator.toSeq
+      assert(fooResults.size === 0)
+      val barResults = barResult.iterator.toSeq
+      assert(barResults.size === 0)
+      val fooErrors = fooError.iterator.toSeq
+      assert(fooErrors.size === 1)
+      assert(fooErrors.head.id.get === foo.id.get)
+      val barErrors = barError.iterator.toSeq
+      assert(barErrors.size === 10)
+      barErrors.zip(bars).foreach {
+        case (actual, expected) =>
+          assert(actual.id.get === expected.id.get)
+          assert(actual.fooId.get === expected.fooId.get)
+      }
+      val nResults = nResult.iterator.toSeq
+      assert(nResults.size === 1)
+      assert(nResults.head.n.get === 10)
+    }
+
+    fragment.reset()
+    assert(fooResult.iterator.size === 0)
+    assert(barResult.iterator.size === 0)
+    assert(fooError.iterator.size === 0)
+    assert(barError.iterator.size === 0)
+    assert(nResult.iterator.size === 0)
   }
 }
 
@@ -664,6 +839,25 @@ object CoGroupOperatorCompilerSpec {
           barError.add(barHead)
           barsIter.foreach(barError.add)
         }
+      }
+      this.n.n.modify(n)
+      nResult.add(this.n)
+    }
+
+    @CoGroup
+    def cogroupWithView(
+      foos: JList[Foo], bars: JList[Bar],
+      v: View[Foo], gv: GroupView[Foo],
+      fooResult: Result[Foo], barResult: Result[Bar],
+      fooError: Result[Foo], barError: Result[Bar],
+      nResult: Result[N],
+      n: Int): Unit = {
+      if (foos.size == 1 && bars.size == 1) {
+        fooResult.add(foos(0))
+        barResult.add(bars(0))
+      } else {
+        foos.foreach(fooError.add)
+        bars.foreach(barError.add)
       }
       this.n.n.modify(n)
       nResult.add(this.n)

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/ExtractOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/ExtractOperatorCompilerSpec.scala
@@ -22,20 +22,26 @@ import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.{ ClassDescription, ImmediateDescription }
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
-import com.asakusafw.runtime.core.Result
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, Result, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.{ IntOption, LongOption, StringOption }
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.{ Fragment, GenericOutputFragment }
 import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.operator.Extract
 
@@ -71,7 +77,7 @@ class ExtractOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
 
       val fragment = cls
         .getConstructor(
-          classOf[Map[BroadcastId, Broadcast[_]]],
+          classOf[Map[BroadcastId, Broadcasted[_]]],
           classOf[Fragment[_]], classOf[Fragment[_]])
         .newInstance(Map.empty, out1, out2)
 
@@ -124,9 +130,94 @@ class ExtractOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, out1, out2)
+
+    fragment.reset()
+    val input = new Input()
+    for (i <- 0 until 10) {
+      input.i.modify(i)
+      input.l.modify(i)
+      fragment.add(input)
+    }
+    out1.iterator.zipWithIndex.foreach {
+      case (output, i) =>
+        assert(output.i.get === i)
+        assert(output.s.isNull)
+    }
+    out2.iterator.zipWithIndex.foreach {
+      case (output, i) =>
+        assert(output.l.get === i / 10)
+        assert(output.s.isNull)
+    }
+
+    fragment.reset()
+  }
+
+  it should "compile Extract operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Input]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Input]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[Extract], classOf[ExtractOperator], "extractWithView")
+      .input("input", ClassDescription.of(classOf[Input]))
+      .input("v", ClassDescription.of(classOf[Input]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Input]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("i"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("output1", ClassDescription.of(classOf[IntOutput]))
+      .output("output2", ClassDescription.of(classOf[LongOutput]))
+      .argument("n", ImmediateDescription.of(10))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Input]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val out1 = new GenericOutputFragment[IntOutput]()
+    val out2 = new GenericOutputFragment[LongOutput]()
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Input())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val input = new Input()
+        input.i.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(input.i)) -> Seq(input)
+      }.toMap)
+
+    val fragment = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]],
+        classOf[Fragment[_]], classOf[Fragment[_]])
+      .newInstance(Map(
+        getBroadcastId(vMarker) -> view,
+        getBroadcastId(gvMarker) -> groupview),
+        out1, out2)
 
     fragment.reset()
     val input = new Input()
@@ -278,6 +369,22 @@ object ExtractOperatorCompilerSpec {
       for (_ <- 0 until n) {
         l.getLOption.copyFrom(in.getLOption)
         out2.add(l.asInstanceOf[LO])
+      }
+    }
+
+    @Extract
+    def extractWithView(
+      in: Input,
+      v: View[Input],
+      gv: GroupView[Input],
+      out1: Result[IntOutput],
+      out2: Result[LongOutput],
+      n: Int): Unit = {
+      i.i.copyFrom(in.getIOption)
+      out1.add(i)
+      for (_ <- 0 until n) {
+        l.l.copyFrom(in.getLOption)
+        out2.add(l)
       }
     }
   }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/LoggingOperatorCompilerSpec.scala
@@ -22,22 +22,28 @@ import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.bridge.broker.{ ResourceBroker, ResourceSession }
 import com.asakusafw.lang.compiler.model.description.{ ClassDescription, ImmediateDescription }
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
-import com.asakusafw.runtime.core.{ HadoopConfiguration, Report, ResourceConfiguration }
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core._
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.{ IntOption, LongOption }
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.{ Fragment, GenericOutputFragment }
 import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.operator.Logging
 
@@ -70,7 +76,7 @@ class LoggingOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
 
       withResourceBroker {
         val fragment =
-          cls.getConstructor(classOf[Map[BroadcastId, Broadcast[_]]], classOf[Fragment[_]])
+          cls.getConstructor(classOf[Map[BroadcastId, Broadcasted[_]]], classOf[Fragment[_]])
             .newInstance(Map.empty, out)
         fragment.reset()
 
@@ -116,7 +122,7 @@ class LoggingOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
 
       withResourceBroker {
         val fragment =
-          cls.getConstructor(classOf[Map[BroadcastId, Broadcast[_]]], classOf[Fragment[_]])
+          cls.getConstructor(classOf[Map[BroadcastId, Broadcasted[_]]], classOf[Fragment[_]])
             .newInstance(Map.empty, out)
 
         fragment.reset()
@@ -142,6 +148,94 @@ class LoggingOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
               case _ => "INFO"
             },
               s"[${level.name}] f: F(${i}), n: 10")))
+      }
+    }
+
+    it should s"compile Extract operator with view: Logging.Level.${level}" in {
+      val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+        .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+      val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+        .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+      val operator = OperatorExtractor
+        .extract(classOf[Logging], classOf[LoggingOperator], s"loggingWithView_${level.name.toLowerCase}")
+        .input("in", ClassDescription.of(classOf[Foo]))
+        .input("v", ClassDescription.of(classOf[Foo]),
+          new Consumer[Operator.InputOptionBuilder] {
+            override def accept(builder: Operator.InputOptionBuilder): Unit = {
+              builder
+                .unit(OperatorInput.InputUnit.WHOLE)
+                .group(Groups.parse(Seq.empty, Seq.empty))
+                .upstream(vMarker.getOutput)
+            }
+          })
+        .input("gv", ClassDescription.of(classOf[Foo]),
+          new Consumer[Operator.InputOptionBuilder] {
+            override def accept(builder: Operator.InputOptionBuilder): Unit = {
+              builder
+                .unit(OperatorInput.InputUnit.WHOLE)
+                .group(Groups.parse(Seq("i"), Seq.empty))
+                .upstream(gvMarker.getOutput)
+            }
+          })
+        .output("out", ClassDescription.of(classOf[Foo]))
+        .argument("n", ImmediateDescription.of(10))
+        .build()
+
+      implicit val context = newOperatorCompilerContext("flowId")
+
+      val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
+      context.addClass(context.broadcastIds)
+      val cls = context.loadClass[Fragment[Foo]](thisType.getClassName)
+
+      val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+      def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+        val sn = marker.getSerialNumber
+        broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+      }
+
+      val out = new GenericOutputFragment[Foo]()
+
+      val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+      val groupview = new MockBroadcast(1,
+        (0 until 10).map { i =>
+          val foo = new Foo()
+          foo.i.modify(i)
+          new ShuffleKey(WritableSerDe.serialize(foo.i)) -> Seq(foo)
+        }.toMap)
+
+      withResourceBroker {
+        val fragment =
+          cls.getConstructor(classOf[Map[BroadcastId, Broadcasted[_]]], classOf[Fragment[_]])
+            .newInstance(
+              Map(
+                getBroadcastId(vMarker) -> view,
+                getBroadcastId(gvMarker) -> groupview),
+              out)
+
+        fragment.reset()
+        val foo = new Foo()
+        for (i <- 0 until 10) {
+          foo.i.modify(i)
+          foo.l.modify(i * 10)
+          fragment.add(foo)
+        }
+        out.iterator.zipWithIndex.foreach {
+          case (output, i) =>
+            assert(output.i.get === i)
+            assert(output.l.get === i * 10)
+        }
+
+        fragment.reset()
+
+        assert(Logs.get() ===
+          (0 until 10).map(i =>
+            (level match {
+              case Logging.Level.ERROR => "ERROR"
+              case Logging.Level.WARN => "WARN"
+              case _ => "INFO"
+            },
+              s"[${level.name}] foo: Foo(${i}, ${i * 10}), n: 10")))
       }
     }
   }
@@ -227,6 +321,15 @@ object LoggingOperatorCompilerSpec {
       s"[ERROR] f: F(${f.getIOption.get}), n: ${n}"
     }
 
+    @Logging(Logging.Level.ERROR)
+    def loggingWithView_error(
+      foo: Foo,
+      v: View[Foo],
+      gv: GroupView[Foo],
+      n: Int): String = {
+      s"[ERROR] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
+    }
+
     @Logging(Logging.Level.WARN)
     def logging_warn(
       foo: Foo,
@@ -239,6 +342,15 @@ object LoggingOperatorCompilerSpec {
       f: F,
       n: Int): String = {
       s"[WARN] f: F(${f.getIOption.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.WARN)
+    def loggingWithView_warn(
+      foo: Foo,
+      v: View[Foo],
+      gv: GroupView[Foo],
+      n: Int): String = {
+      s"[WARN] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
     }
 
     @Logging(Logging.Level.INFO)
@@ -255,6 +367,15 @@ object LoggingOperatorCompilerSpec {
       s"[INFO] f: F(${f.getIOption.get}), n: ${n}"
     }
 
+    @Logging(Logging.Level.INFO)
+    def loggingWithView_info(
+      foo: Foo,
+      v: View[Foo],
+      gv: GroupView[Foo],
+      n: Int): String = {
+      s"[INFO] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
+    }
+
     @Logging(Logging.Level.DEBUG)
     def logging_debug(
       foo: Foo,
@@ -267,6 +388,15 @@ object LoggingOperatorCompilerSpec {
       f: F,
       n: Int): String = {
       s"[DEBUG] f: F(${f.getIOption.get}), n: ${n}"
+    }
+
+    @Logging(Logging.Level.DEBUG)
+    def loggingWithView_debug(
+      foo: Foo,
+      v: View[Foo],
+      gv: GroupView[Foo],
+      n: Int): String = {
+      s"[DEBUG] foo: Foo(${foo.i.get}, ${foo.l.get}), n: ${n}"
     }
   }
 }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/SplitOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/SplitOperatorCompilerSpec.scala
@@ -26,7 +26,7 @@ import java.io.{ DataInput, DataOutput }
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
@@ -66,7 +66,7 @@ class SplitOperatorCompilerSpec extends FlatSpec with UsingCompilerContext {
     val bars = new GenericOutputFragment[Bar]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]]).newInstance(Map.empty, foos, bars)
 
     fragment.reset()

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterBranchOperatorCompilerSpec.scala
@@ -24,14 +24,15 @@ import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
 import java.util.{ List => JList }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription
-import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator }
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning.PlanMarker
 import com.asakusafw.runtime.model.DataModel
@@ -61,7 +62,14 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val operator = OperatorExtractor
       .extract(classOf[MasterBranchOp], classOf[MasterBranchOperator], "branch")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("low", ClassDescription.of(classOf[Bar]))
@@ -84,7 +92,7 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val high = new GenericOutputFragment[Bar]()
 
     val ctor = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -142,7 +150,14 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val operator = OperatorExtractor
       .extract(classOf[MasterBranchOp], classOf[MasterBranchOperator], "branchWithSelection")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("low", ClassDescription.of(classOf[Bar]))
@@ -165,7 +180,7 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val high = new GenericOutputFragment[Bar]()
 
     val ctor = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -225,7 +240,14 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val operator = OperatorExtractor
       .extract(classOf[MasterBranchOp], classOf[MasterBranchOperator], "branchp")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("low", ClassDescription.of(classOf[Bar]))
@@ -248,7 +270,7 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val high = new GenericOutputFragment[Bar]()
 
     val ctor = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -307,7 +329,14 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val operator = OperatorExtractor
       .extract(classOf[MasterBranchOp], classOf[MasterBranchOperator], "branchWithSelectionp")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("low", ClassDescription.of(classOf[Bar]))
@@ -330,7 +359,7 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val high = new GenericOutputFragment[Bar]()
 
     val ctor = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -389,7 +418,13 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val operator = OperatorExtractor
       .extract(classOf[MasterBranchOp], classOf[MasterBranchOperator], "branch")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")))
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("low", ClassDescription.of(classOf[Bar]))
@@ -406,7 +441,7 @@ class BroadcastMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompi
     val high = new GenericOutputFragment[Bar]()
 
     val ctor = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
 
     {

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterCheckOperatorCompilerSpec.scala
@@ -18,7 +18,7 @@ package operator
 package user.join
 
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
+import org.scalatest.{ Assertions, FlatSpec }
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
@@ -34,6 +34,7 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.compiler.broadcast.MockBroadcast
@@ -281,6 +282,134 @@ class BroadcastMasterCheckOperatorCompilerSpec extends FlatSpec with UsingCompil
       assert(missed.iterator.size === 0)
     }
   }
+
+  it should "compile MasterCheck operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val foosMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[MasterCheckOp], classOf[MasterCheckOperator], "checkWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("found", ClassDescription.of(classOf[Bar]))
+      .output("missed", ClassDescription.of(classOf[Bar]))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Bar]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val found = new GenericOutputFragment[Bar]()
+    val missed = new GenericOutputFragment[Bar]()
+
+    val ctor = cls.getConstructor(
+      classOf[Map[BroadcastId, Broadcasted[_]]],
+      classOf[Fragment[_]], classOf[Fragment[_]])
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    {
+      val foo = new Foo()
+      foo.id.modify(0)
+      val foos = Seq(foo)
+      val shuffleKey = new ShuffleKey(
+        WritableSerDe.serialize(foo.id), Array.emptyByteArray)
+      val fragment = ctor.newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview,
+          getBroadcastId(foosMarker) -> new MockBroadcast(2, Map(shuffleKey -> foos))),
+        found,
+        missed)
+      fragment.reset()
+      val bars = (0 until 10).map { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(0)
+        fragment.add(bar)
+      }
+      val founds = found.iterator.toSeq
+      assert(founds.size === 5)
+      assert(founds.map(_.id.get) === (0 until 10 by 2))
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 5)
+      assert(misseds.map(_.id.get) === (1 until 10 by 2))
+
+      fragment.reset()
+      assert(found.iterator.size === 0)
+      assert(missed.iterator.size === 0)
+    }
+
+    {
+      val fragment = ctor.newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview,
+          getBroadcastId(foosMarker) -> new MockBroadcast(2, Map.empty)),
+        found,
+        missed)
+      fragment.reset()
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      fragment.add(bar)
+      val founds = found.iterator.toSeq
+      assert(founds.size === 0)
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 1)
+      assert(misseds.head.id.get === 10)
+
+      fragment.reset()
+      assert(found.iterator.size === 0)
+      assert(missed.iterator.size === 0)
+    }
+  }
 }
 
 object BroadcastMasterCheckOperatorCompilerSpec {
@@ -331,7 +460,7 @@ object BroadcastMasterCheckOperatorCompilerSpec {
     def getFooIdOption: IntOption = fooId
   }
 
-  class MasterCheckOperator {
+  class MasterCheckOperator extends Assertions {
 
     @MasterCheckOp
     def check(foo: Foo, bar: Bar): Boolean = ???
@@ -341,6 +470,28 @@ object BroadcastMasterCheckOperatorCompilerSpec {
 
     @MasterSelection
     def select(foos: JList[Foo], bar: Bar): Foo = {
+      if (bar.id.get % 2 == 0) {
+        foos.headOption.orNull
+      } else {
+        null
+      }
+    }
+
+    @MasterCheckOp(selection = "selectWithView")
+    def checkWithView(foo: Foo, bar: Bar, v: View[Foo], gv: GroupView[Foo]): Boolean = ???
+
+    @MasterSelection
+    def selectWithView(foos: JList[Foo], bar: Bar, v: View[Foo], gv: GroupView[Foo]): Foo = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      val group = gv.find(bar.id).toSeq
+      if (bar.id.get < 10) {
+        assert(group.size === 1)
+        assert(group.head.id.get === bar.id.get)
+      } else {
+        assert(group.size === 0)
+      }
       if (bar.id.get % 2 == 0) {
         foos.headOption.orNull
       } else {

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinOperatorCompilerSpec.scala
@@ -18,7 +18,7 @@ package operator
 package user.join
 
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
+import org.scalatest.{ Assertions, FlatSpec }
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
@@ -34,6 +34,7 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.{ IntOption, StringOption }
 import com.asakusafw.spark.compiler.broadcast.MockBroadcast
@@ -297,6 +298,141 @@ class BroadcastMasterJoinOperatorCompilerSpec extends FlatSpec with UsingCompile
       assert(missed.iterator.size === 0)
     }
   }
+
+  it should "compile MasterJoin operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val foosMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[MasterJoinOp], classOf[MasterJoinOperator], "joinWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("joined", ClassDescription.of(classOf[FooBar]))
+      .output("missed", ClassDescription.of(classOf[Bar]))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Bar]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val joined = new GenericOutputFragment[FooBar]()
+    val missed = new GenericOutputFragment[Bar]()
+
+    val ctor = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]],
+        classOf[Fragment[_]], classOf[Fragment[_]])
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    {
+      val foo = new Foo()
+      foo.id.modify(0)
+      foo.foo.modify("foo")
+      val foos = Seq(foo)
+      val shuffleKey = new ShuffleKey(
+        WritableSerDe.serialize(foo.id), Array.emptyByteArray)
+      val fragment = ctor.newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview,
+          getBroadcastId(foosMarker) -> new MockBroadcast(2, Map(shuffleKey -> foos))),
+        joined,
+        missed)
+      fragment.reset()
+      (0 until 10).foreach { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(0)
+        bar.bar.modify(s"bar ${i}")
+        fragment.add(bar)
+      }
+      val joineds = joined.iterator.toSeq
+      assert(joineds.size === 5)
+      assert(joineds.map(_.id.get) === (0 until 10 by 2).map(_ => 0))
+      assert(joineds.map(_.foo.getAsString) === (0 until 10 by 2).map(_ => "foo"))
+      assert(joineds.map(_.bar.getAsString) === (0 until 10 by 2).map(i => s"bar ${i}"))
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 5)
+      assert(misseds.map(_.id.get) === (1 until 10 by 2))
+      assert(misseds.map(_.bar.getAsString) === (1 until 10 by 2).map(i => s"bar ${i}"))
+
+      fragment.reset()
+      assert(joined.iterator.size === 0)
+      assert(missed.iterator.size === 0)
+    }
+
+    {
+      val fragment = ctor.newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview,
+          getBroadcastId(foosMarker) -> new MockBroadcast(2, Map.empty)),
+        joined,
+        missed)
+      fragment.reset()
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      bar.bar.modify("bar")
+      fragment.add(bar)
+      val joineds = joined.iterator.toSeq
+      assert(joineds.size === 0)
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 1)
+      assert(misseds.head.id.get === 10)
+
+      fragment.reset()
+      assert(joined.iterator.size === 0)
+      assert(missed.iterator.size === 0)
+    }
+  }
 }
 
 object BroadcastMasterJoinOperatorCompilerSpec {
@@ -398,7 +534,7 @@ object BroadcastMasterJoinOperatorCompilerSpec {
     def getBarOption: StringOption = bar
   }
 
-  class MasterJoinOperator {
+  class MasterJoinOperator extends Assertions {
 
     @MasterJoinOp
     def join(foo: Foo, bar: Bar): FooBar = ???
@@ -408,6 +544,28 @@ object BroadcastMasterJoinOperatorCompilerSpec {
 
     @MasterSelection
     def select(foos: JList[Foo], bar: Bar): Foo = {
+      if (bar.id.get % 2 == 0) {
+        foos.headOption.orNull
+      } else {
+        null
+      }
+    }
+
+    @MasterJoinOp(selection = "selectWithView")
+    def joinWithView(foo: Foo, bar: Bar, v: View[Foo], gv: GroupView[Foo]): FooBar = ???
+
+    @MasterSelection
+    def selectWithView(foos: JList[Foo], bar: Bar, v: View[Foo], gv: GroupView[Foo]): Foo = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      val group = gv.find(bar.id).toSeq
+      if (bar.id.get < 10) {
+        assert(group.size === 1)
+        assert(group.head.id.get === bar.id.get)
+      } else {
+        assert(group.size === 0)
+      }
       if (bar.id.get % 2 == 0) {
         foos.headOption.orNull
       } else {

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompilerSpec.scala
@@ -23,14 +23,15 @@ import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
 import java.util.{ List => JList }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription
-import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator }
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning.PlanMarker
 import com.asakusafw.runtime.model.DataModel
@@ -60,7 +61,14 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
     val operator = OperatorExtractor
       .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "update")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("updated", ClassDescription.of(classOf[Bar]))
@@ -84,7 +92,7 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
 
     val ctor = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -142,7 +150,14 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
     val operator = OperatorExtractor
       .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "updateWithSelection")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("updated", ClassDescription.of(classOf[Bar]))
@@ -166,7 +181,7 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
 
     val ctor = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -227,7 +242,14 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
     val operator = OperatorExtractor
       .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "updateWithSelectionWith1Argument")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("updated", ClassDescription.of(classOf[Bar]))
@@ -251,7 +273,7 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
 
     val ctor = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -311,7 +333,14 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
     val operator = OperatorExtractor
       .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "updatep")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("updated", ClassDescription.of(classOf[Bar]))
@@ -335,7 +364,7 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
 
     val ctor = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -394,7 +423,14 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
     val operator = OperatorExtractor
       .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "updateWithSelectionp")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")), foosMarker.getOutput)
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("updated", ClassDescription.of(classOf[Bar]))
@@ -418,7 +454,7 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
 
     val ctor = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
 
     {
@@ -476,7 +512,13 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
     val operator = OperatorExtractor
       .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "update")
       .input("foos", ClassDescription.of(classOf[Foo]),
-        Groups.parse(Seq("id")))
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+          }
+        })
       .input("bars", ClassDescription.of(classOf[Bar]),
         Groups.parse(Seq("fooId"), Seq("+id")))
       .output("updated", ClassDescription.of(classOf[Bar]))
@@ -493,7 +535,7 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
 
     val ctor = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
 
     {

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/BroadcastMasterJoinUpdateOperatorCompilerSpec.scala
@@ -18,7 +18,7 @@ package operator
 package user.join
 
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
+import org.scalatest.{ Assertions, FlatSpec }
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
@@ -34,6 +34,7 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
 import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.compiler.broadcast.MockBroadcast
@@ -556,6 +557,135 @@ class BroadcastMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingC
       assert(missed.iterator.size === 0)
     }
   }
+
+  it should "compile MasterJoinUpdate operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val foosMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "updateWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id")))
+              .upstream(foosMarker.getOutput)
+          }
+        })
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("updated", ClassDescription.of(classOf[Bar]))
+      .output("missed", ClassDescription.of(classOf[Bar]))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.ExtractType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Bar]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val updated = new GenericOutputFragment[Bar]()
+    val missed = new GenericOutputFragment[Bar]()
+
+    val ctor = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]],
+        classOf[Fragment[_]], classOf[Fragment[_]])
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    {
+      val foo = new Foo()
+      foo.id.modify(0)
+      val foos = Seq(foo)
+      val shuffleKey = new ShuffleKey(
+        WritableSerDe.serialize(foo.id), Array.emptyByteArray)
+      val fragment = ctor.newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview,
+          getBroadcastId(foosMarker) -> new MockBroadcast(0, Map(shuffleKey -> foos))),
+        updated,
+        missed)
+      fragment.reset()
+      (0 until 10).foreach { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(0)
+        fragment.add(bar)
+      }
+      val updateds = updated.iterator.toSeq
+      assert(updateds.size === 5)
+      assert(updateds.map(_.id.get) === (0 until 10 by 2))
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 5)
+      assert(misseds.map(_.id.get) === (1 until 10 by 2))
+
+      fragment.reset()
+      assert(updated.iterator.size === 0)
+      assert(missed.iterator.size === 0)
+    }
+
+    {
+      val fragment = ctor.newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview,
+          getBroadcastId(foosMarker) -> new MockBroadcast(0, Map.empty)),
+        updated,
+        missed)
+      fragment.reset()
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      fragment.add(bar)
+      val updateds = updated.iterator.toSeq
+      assert(updateds.size === 0)
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 1)
+      assert(misseds.head.id.get === 10)
+
+      fragment.reset()
+      assert(updated.iterator.size === 0)
+      assert(missed.iterator.size === 0)
+    }
+  }
 }
 
 object BroadcastMasterJoinUpdateOperatorCompilerSpec {
@@ -615,7 +745,7 @@ object BroadcastMasterJoinUpdateOperatorCompilerSpec {
     def getFooIdOption: IntOption = fooId
   }
 
-  class MasterJoinUpdateOperator {
+  class MasterJoinUpdateOperator extends Assertions {
 
     @MasterJoinUpdateOp
     def update(foo: Foo, bar: Bar): Unit = {}
@@ -656,6 +786,32 @@ object BroadcastMasterJoinUpdateOperatorCompilerSpec {
         }
       } else {
         null.asInstanceOf[F]
+      }
+    }
+
+    @MasterJoinUpdateOp(selection = "selectWithView")
+    def updateWithView(foo: Foo, bar: Bar, v: View[Foo], gv: GroupView[Foo]): Unit = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      val group = gv.find(bar.id).toSeq
+      if (bar.id.get < 10) {
+        assert(group.size === 1)
+        assert(group.head.id.get === bar.id.get)
+      } else {
+        assert(group.size === 0)
+      }
+    }
+
+    @MasterSelection
+    def selectWithView(foos: JList[Foo], bar: Bar, v: View[Foo]): Foo = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      if (bar.id.get % 2 == 0) {
+        foos.headOption.orNull
+      } else {
+        null
       }
     }
   }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterBranchOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterBranchOperatorCompilerSpec.scala
@@ -19,25 +19,31 @@ package user
 package join
 
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
+import org.scalatest.{ Assertions, FlatSpec }
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
 import java.util.{ List => JList }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription
-import com.asakusafw.lang.compiler.model.graph.Groups
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.IntOption
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.{ Fragment, GenericOutputFragment }
 import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.operator.{ MasterBranch => MasterBranchOp, MasterSelection }
 
@@ -70,7 +76,7 @@ class ShuffledMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompil
     val high = new GenericOutputFragment[Bar]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, low, high)
 
@@ -135,7 +141,7 @@ class ShuffledMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompil
     val high = new GenericOutputFragment[Bar]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, low, high)
 
@@ -203,7 +209,7 @@ class ShuffledMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompil
     val high = new GenericOutputFragment[Bar]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, low, high)
 
@@ -268,9 +274,119 @@ class ShuffledMasterBranchOperatorCompilerSpec extends FlatSpec with UsingCompil
     val high = new GenericOutputFragment[Bar]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, low, high)
+
+    {
+      fragment.reset()
+      val foo = new Foo()
+      foo.id.modify(10)
+      val foos = Seq(foo)
+      val bars = (0 until 10).map { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(10)
+        bar
+      }
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val lows = low.iterator.toSeq
+      assert(lows.size === 5)
+      assert(lows.map(_.id.get) === (1 until 10 by 2))
+      val highs = high.iterator.toSeq
+      assert(highs.size === 5)
+      assert(highs.map(_.id.get) === (0 until 10 by 2))
+    }
+
+    fragment.reset()
+    assert(low.iterator.size === 0)
+    assert(high.iterator.size === 0)
+
+    {
+      fragment.reset()
+      val foos = Seq.empty[Foo]
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      val bars = Seq(bar)
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val lows = low.iterator.toSeq
+      assert(lows.size === 1)
+      assert(lows.head.id.get === 10)
+      val highs = high.iterator.toSeq
+      assert(highs.size === 0)
+    }
+
+    fragment.reset()
+    assert(low.iterator.size === 0)
+    assert(high.iterator.size === 0)
+  }
+
+  it should "compile MasterBranch operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[MasterBranchOp], classOf[MasterBranchOperator], "branchWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        Groups.parse(Seq("id")))
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("low", ClassDescription.of(classOf[Bar]))
+      .output("high", ClassDescription.of(classOf[Bar]))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.CoGroupType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Seq[Iterator[_]]]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val low = new GenericOutputFragment[Bar]()
+    val high = new GenericOutputFragment[Bar]()
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    val fragment = cls.getConstructor(
+      classOf[Map[BroadcastId, Broadcasted[_]]],
+      classOf[Fragment[_]], classOf[Fragment[_]])
+      .newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview),
+        low, high)
 
     {
       fragment.reset()
@@ -374,7 +490,7 @@ object ShuffledMasterBranchOperatorCompilerSpec {
     def getFooIdOption: IntOption = fooId
   }
 
-  class MasterBranchOperator {
+  class MasterBranchOperator extends Assertions {
 
     @MasterBranchOp
     def branch(foo: Foo, bar: Bar): BranchOperatorCompilerSpecTestBranch = {
@@ -431,6 +547,37 @@ object ShuffledMasterBranchOperatorCompilerSpec {
         }
       } else {
         null.asInstanceOf[F]
+      }
+    }
+
+    @MasterBranchOp(selection = "selectWithView")
+    def branchWithView(foo: Foo, bar: Bar, v: View[Foo], gv: GroupView[Foo]): BranchOperatorCompilerSpecTestBranch = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      val group = gv.find(bar.id).toSeq
+      if (bar.id.get < 10) {
+        assert(group.size === 1)
+        assert(group.head.id.get === bar.id.get)
+      } else {
+        assert(group.size === 0)
+      }
+      if (foo == null || foo.id.get < 5) {
+        BranchOperatorCompilerSpecTestBranch.LOW
+      } else {
+        BranchOperatorCompilerSpecTestBranch.HIGH
+      }
+    }
+
+    @MasterSelection
+    def selectWithView(foos: JList[Foo], bar: Bar, v: View[Foo]): Foo = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      if (bar.id.get % 2 == 0) {
+        foos.headOption.orNull
+      } else {
+        null
       }
     }
   }

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterCheckOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterCheckOperatorCompilerSpec.scala
@@ -18,25 +18,31 @@ package operator
 package user.join
 
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
+import org.scalatest.{ Assertions, FlatSpec }
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
 import java.util.{ List => JList }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription
-import com.asakusafw.lang.compiler.model.graph.Groups
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.IntOption
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.{ Fragment, GenericOutputFragment }
 import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.operator.{ MasterCheck => MasterCheckOp, MasterSelection }
 
@@ -69,7 +75,7 @@ class ShuffledMasterCheckOperatorCompilerSpec extends FlatSpec with UsingCompile
     val missed = new GenericOutputFragment[Bar]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, found, missed)
 
@@ -134,9 +140,119 @@ class ShuffledMasterCheckOperatorCompilerSpec extends FlatSpec with UsingCompile
     val missed = new GenericOutputFragment[Bar]()
 
     val fragment = cls.getConstructor(
-      classOf[Map[BroadcastId, Broadcast[_]]],
+      classOf[Map[BroadcastId, Broadcasted[_]]],
       classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, found, missed)
+
+    {
+      fragment.reset()
+      val foo = new Foo()
+      foo.id.modify(0)
+      val foos = Seq(foo)
+      val bars = (0 until 10).map { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(0)
+        bar
+      }
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val founds = found.iterator.toSeq
+      assert(founds.size === 5)
+      assert(founds.map(_.id.get) === (0 until 10 by 2))
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 5)
+      assert(misseds.map(_.id.get) === (1 until 10 by 2))
+    }
+
+    fragment.reset()
+    assert(found.iterator.size === 0)
+    assert(missed.iterator.size === 0)
+
+    {
+      fragment.reset()
+      val foos = Seq.empty[Foo]
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      val bars = Seq(bar)
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val founds = found.iterator.toSeq
+      assert(founds.size === 0)
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 1)
+      assert(misseds.head.id.get === 10)
+    }
+
+    fragment.reset()
+    assert(found.iterator.size === 0)
+    assert(missed.iterator.size === 0)
+  }
+
+  it should "compile MasterCheck operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[MasterCheckOp], classOf[MasterCheckOperator], "checkWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        Groups.parse(Seq("id")))
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("found", ClassDescription.of(classOf[Bar]))
+      .output("missed", ClassDescription.of(classOf[Bar]))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.CoGroupType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Seq[Iterator[_]]]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val found = new GenericOutputFragment[Bar]()
+    val missed = new GenericOutputFragment[Bar]()
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    val fragment = cls.getConstructor(
+      classOf[Map[BroadcastId, Broadcasted[_]]],
+      classOf[Fragment[_]], classOf[Fragment[_]])
+      .newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview),
+        found, missed)
 
     {
       fragment.reset()
@@ -231,7 +347,7 @@ object ShuffledMasterCheckOperatorCompilerSpec {
     def getFooIdOption: IntOption = fooId
   }
 
-  class MasterCheckOperator {
+  class MasterCheckOperator extends Assertions {
 
     @MasterCheckOp
     def check(foo: Foo, bar: Bar): Boolean = ???
@@ -241,6 +357,28 @@ object ShuffledMasterCheckOperatorCompilerSpec {
 
     @MasterSelection
     def select(foos: JList[Foo], bar: Bar): Foo = {
+      if (bar.id.get % 2 == 0) {
+        foos.headOption.orNull
+      } else {
+        null
+      }
+    }
+
+    @MasterCheckOp(selection = "selectWithView")
+    def checkWithView(foo: Foo, bar: Bar, v: View[Foo], gv: GroupView[Foo]): Boolean = ???
+
+    @MasterSelection
+    def selectWithView(foos: JList[Foo], bar: Bar, v: View[Foo], gv: GroupView[Foo]): Foo = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      val group = gv.find(bar.id).toSeq
+      if (bar.id.get < 10) {
+        assert(group.size === 1)
+        assert(group.head.id.get === bar.id.get)
+      } else {
+        assert(group.size === 0)
+      }
       if (bar.id.get % 2 == 0) {
         foos.headOption.orNull
       } else {

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinOperatorCompilerSpec.scala
@@ -18,25 +18,31 @@ package operator
 package user.join
 
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
+import org.scalatest.{ Assertions, FlatSpec }
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
 import java.util.{ List => JList }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription
-import com.asakusafw.lang.compiler.model.graph.Groups
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.{ IntOption, StringOption }
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.{ Fragment, GenericOutputFragment }
 import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.model.{ Joined, Key }
 import com.asakusafw.vocabulary.operator.{ MasterJoin => MasterJoinOp, MasterSelection }
@@ -71,7 +77,7 @@ class ShuffledMasterJoinOperatorCompilerSpec extends FlatSpec with UsingCompiler
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, joined, missed)
 
@@ -142,9 +148,126 @@ class ShuffledMasterJoinOperatorCompilerSpec extends FlatSpec with UsingCompiler
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, joined, missed)
+
+    {
+      fragment.reset()
+      val foo = new Foo()
+      foo.id.modify(0)
+      foo.foo.modify("foo")
+      val foos = Seq(foo)
+      val bars = (0 until 10).map { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(0)
+        bar.bar.modify(s"bar ${i}")
+        bar
+      }
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val joineds = joined.iterator.toSeq
+      assert(joineds.size === 5)
+      assert(joineds.map(_.id.get) === (0 until 10 by 2).map(_ => 0))
+      assert(joineds.map(_.foo.getAsString) === (0 until 10 by 2).map(_ => "foo"))
+      assert(joineds.map(_.bar.getAsString) === (0 until 10 by 2).map(i => s"bar ${i}"))
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 5)
+      assert(misseds.map(_.id.get) === (1 until 10 by 2))
+      assert(misseds.map(_.bar.getAsString) === (1 until 10 by 2).map(i => s"bar ${i}"))
+    }
+
+    fragment.reset()
+    assert(joined.iterator.size === 0)
+    assert(missed.iterator.size === 0)
+
+    {
+      fragment.reset()
+      val foos = Seq.empty[Foo]
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      bar.bar.modify("bar")
+      val bars = Seq(bar)
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val joineds = joined.iterator.toSeq
+      assert(joineds.size === 0)
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 1)
+      assert(misseds.head.id.get === 10)
+    }
+
+    fragment.reset()
+    assert(joined.iterator.size === 0)
+    assert(missed.iterator.size === 0)
+  }
+
+  it should "compile MasterJoin operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[MasterJoinOp], classOf[MasterJoinOperator], "joinWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        Groups.parse(Seq("id")))
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("joined", ClassDescription.of(classOf[FooBar]))
+      .output("missed", ClassDescription.of(classOf[Bar]))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.CoGroupType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Seq[Iterator[_]]]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val joined = new GenericOutputFragment[FooBar]()
+    val missed = new GenericOutputFragment[Bar]()
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    val fragment = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]],
+        classOf[Fragment[_]], classOf[Fragment[_]])
+      .newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview),
+        joined, missed)
 
     {
       fragment.reset()
@@ -296,7 +419,7 @@ object ShuffledMasterJoinOperatorCompilerSpec {
     def getBarOption: StringOption = bar
   }
 
-  class MasterJoinOperator {
+  class MasterJoinOperator extends Assertions {
 
     @MasterJoinOp
     def join(foo: Foo, bar: Bar): FooBar = ???
@@ -306,6 +429,28 @@ object ShuffledMasterJoinOperatorCompilerSpec {
 
     @MasterSelection
     def select(foos: JList[Foo], bar: Bar): Foo = {
+      if (bar.id.get % 2 == 0) {
+        foos.headOption.orNull
+      } else {
+        null
+      }
+    }
+
+    @MasterJoinOp(selection = "selectWithView")
+    def joinWithView(foo: Foo, bar: Bar, v: View[Foo], gv: GroupView[Foo]): FooBar = ???
+
+    @MasterSelection
+    def selectWithView(foos: JList[Foo], bar: Bar, v: View[Foo], gv: GroupView[Foo]): Foo = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      val group = gv.find(bar.id).toSeq
+      if (bar.id.get < 10) {
+        assert(group.size === 1)
+        assert(group.head.id.get === bar.id.get)
+      } else {
+        assert(group.size === 0)
+      }
       if (bar.id.get % 2 == 0) {
         foos.headOption.orNull
       } else {

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinUpdateOperatorCompilerSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/operator/user/join/ShuffledMasterJoinUpdateOperatorCompilerSpec.scala
@@ -18,25 +18,31 @@ package operator
 package user.join
 
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
+import org.scalatest.{ Assertions, FlatSpec }
 import org.scalatest.junit.JUnitRunner
 
 import java.io.{ DataInput, DataOutput }
 import java.util.{ List => JList }
+import java.util.function.Consumer
 
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.io.Writable
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 
 import com.asakusafw.lang.compiler.model.description.ClassDescription
-import com.asakusafw.lang.compiler.model.graph.Groups
+import com.asakusafw.lang.compiler.model.graph.{ Groups, MarkerOperator, Operator, OperatorInput }
 import com.asakusafw.lang.compiler.model.testing.OperatorExtractor
+import com.asakusafw.lang.compiler.planning.PlanMarker
+import com.asakusafw.runtime.core.{ GroupView, View }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.value.IntOption
+import com.asakusafw.spark.compiler.broadcast.MockBroadcast
 import com.asakusafw.spark.compiler.spi.{ OperatorCompiler, OperatorType }
 import com.asakusafw.spark.runtime.fragment.{ Fragment, GenericOutputFragment }
 import com.asakusafw.spark.runtime.graph.BroadcastId
+import com.asakusafw.spark.runtime.io.WritableSerDe
+import com.asakusafw.spark.runtime.rdd.ShuffleKey
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.operator.{ MasterJoinUpdate => MasterJoinUpdateOp, MasterSelection }
 
@@ -70,7 +76,7 @@ class ShuffledMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingCo
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, updated, missed)
 
@@ -136,7 +142,7 @@ class ShuffledMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingCo
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, updated, missed)
 
@@ -205,7 +211,7 @@ class ShuffledMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingCo
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, updated, missed)
 
@@ -273,7 +279,7 @@ class ShuffledMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingCo
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, updated, missed)
 
@@ -339,9 +345,120 @@ class ShuffledMasterJoinUpdateOperatorCompilerSpec extends FlatSpec with UsingCo
 
     val fragment = cls
       .getConstructor(
-        classOf[Map[BroadcastId, Broadcast[_]]],
+        classOf[Map[BroadcastId, Broadcasted[_]]],
         classOf[Fragment[_]], classOf[Fragment[_]])
       .newInstance(Map.empty, updated, missed)
+
+    {
+      fragment.reset()
+      val foo = new Foo()
+      foo.id.modify(0)
+      val foos = Seq(foo)
+      val bars = (0 until 10).map { i =>
+        val bar = new Bar()
+        bar.id.modify(i)
+        bar.fooId.modify(0)
+        bar
+      }
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val updateds = updated.iterator.toSeq
+      assert(updateds.size === 5)
+      assert(updateds.map(_.id.get) === (0 until 10 by 2))
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 5)
+      assert(misseds.map(_.id.get) === (1 until 10 by 2))
+    }
+
+    fragment.reset()
+    assert(updated.iterator.size === 0)
+    assert(missed.iterator.size === 0)
+
+    {
+      fragment.reset()
+      val foos = Seq.empty[Foo]
+      val bar = new Bar()
+      bar.id.modify(10)
+      bar.fooId.modify(1)
+      val bars = Seq(bar)
+      fragment.add(IndexedSeq(foos.iterator, bars.iterator))
+      val updateds = updated.iterator.toSeq
+      assert(updateds.size === 0)
+      val misseds = missed.iterator.toSeq
+      assert(misseds.size === 1)
+      assert(misseds.head.id.get === 10)
+    }
+
+    fragment.reset()
+    assert(updated.iterator.size === 0)
+    assert(missed.iterator.size === 0)
+  }
+
+  it should "compile MasterJoinUpdate operator with view" in {
+    val vMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+    val gvMarker = MarkerOperator.builder(ClassDescription.of(classOf[Foo]))
+      .attribute(classOf[PlanMarker], PlanMarker.BROADCAST).build()
+
+    val operator = OperatorExtractor
+      .extract(classOf[MasterJoinUpdateOp], classOf[MasterJoinUpdateOperator], "updateWithView")
+      .input("foos", ClassDescription.of(classOf[Foo]),
+        Groups.parse(Seq("id")))
+      .input("bars", ClassDescription.of(classOf[Bar]),
+        Groups.parse(Seq("fooId"), Seq("+id")))
+      .input("v", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq.empty, Seq.empty))
+              .upstream(vMarker.getOutput)
+          }
+        })
+      .input("gv", ClassDescription.of(classOf[Foo]),
+        new Consumer[Operator.InputOptionBuilder] {
+          override def accept(builder: Operator.InputOptionBuilder): Unit = {
+            builder
+              .unit(OperatorInput.InputUnit.WHOLE)
+              .group(Groups.parse(Seq("id"), Seq.empty))
+              .upstream(gvMarker.getOutput)
+          }
+        })
+      .output("updated", ClassDescription.of(classOf[Bar]))
+      .output("missed", ClassDescription.of(classOf[Bar]))
+      .build()
+
+    implicit val context = newOperatorCompilerContext("flowId")
+
+    val thisType = OperatorCompiler.compile(operator, OperatorType.CoGroupType)
+    context.addClass(context.broadcastIds)
+    val cls = context.loadClass[Fragment[Seq[Iterator[_]]]](thisType.getClassName)
+
+    val broadcastIdsCls = context.loadClass(context.broadcastIds.thisType.getClassName)
+    def getBroadcastId(marker: MarkerOperator): BroadcastId = {
+      val sn = marker.getSerialNumber
+      broadcastIdsCls.getField(context.broadcastIds.getField(sn)).get(null).asInstanceOf[BroadcastId]
+    }
+
+    val updated = new GenericOutputFragment[Bar]()
+    val missed = new GenericOutputFragment[Bar]()
+
+    val view = new MockBroadcast(0, Map(ShuffleKey.empty -> Seq(new Foo())))
+    val groupview = new MockBroadcast(1,
+      (0 until 10).map { i =>
+        val foo = new Foo()
+        foo.id.modify(i)
+        new ShuffleKey(WritableSerDe.serialize(foo.id)) -> Seq(foo)
+      }.toMap)
+
+    val fragment = cls
+      .getConstructor(
+        classOf[Map[BroadcastId, Broadcasted[_]]],
+        classOf[Fragment[_]], classOf[Fragment[_]])
+      .newInstance(
+        Map(
+          getBroadcastId(vMarker) -> view,
+          getBroadcastId(gvMarker) -> groupview),
+        updated, missed)
 
     {
       fragment.reset()
@@ -445,7 +562,7 @@ object ShuffledMasterJoinUpdateOperatorCompilerSpec {
     def getFooIdOption: IntOption = fooId
   }
 
-  class MasterJoinUpdateOperator {
+  class MasterJoinUpdateOperator extends Assertions {
 
     @MasterJoinUpdateOp
     def update(foo: Foo, bar: Bar): Unit = {}
@@ -486,6 +603,32 @@ object ShuffledMasterJoinUpdateOperatorCompilerSpec {
         }
       } else {
         null.asInstanceOf[F]
+      }
+    }
+
+    @MasterJoinUpdateOp(selection = "selectWithView")
+    def updateWithView(foo: Foo, bar: Bar, v: View[Foo], gv: GroupView[Foo]): Unit = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      val group = gv.find(bar.id).toSeq
+      if (bar.id.get < 10) {
+        assert(group.size === 1)
+        assert(group.head.id.get === bar.id.get)
+      } else {
+        assert(group.size === 0)
+      }
+    }
+
+    @MasterSelection
+    def selectWithView(foos: JList[Foo], bar: Bar, v: View[Foo]): Foo = {
+      val view = v.toSeq
+      assert(view.size === 1)
+      assert(view.head.id.isNull())
+      if (bar.id.get % 2 == 0) {
+        foos.headOption.orNull
+      } else {
+        null
       }
     }
   }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/AggregateCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/AggregateCompiler.scala
@@ -55,11 +55,6 @@ class AggregateCompiler extends RoundAwareNodeCompiler {
       s"The primary operator should be user operator: ${primaryOperator}")
     val operator = primaryOperator.asInstanceOf[UserOperator]
 
-    assert(operator.inputs.size == 1,
-      s"The size of inputs should be 1: ${operator.inputs.size}")
-    assert(operator.outputs.size == 1,
-      s"The size of outputs should be 1: ${operator.outputs.size}")
-
     val iterativeInfo = IterativeInfo.get(subplan)
 
     val valueType = operator.inputs.head.dataModelType

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/AggregateCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/AggregateCompiler.scala
@@ -66,14 +66,18 @@ class AggregateCompiler extends RoundAwareNodeCompiler {
           new AggregateClassBuilder(
             valueType,
             combinerType,
-            operator)(
+            operator,
+            mapSideCombine =
+              subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
             subPlanInfo.getLabel,
             subplan.getOutputs.toSeq) with CacheAlways
         case IterativeInfo.RecomputeKind.PARAMETER =>
           new AggregateClassBuilder(
             valueType,
             combinerType,
-            operator)(
+            operator,
+            mapSideCombine =
+              subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
             subPlanInfo.getLabel,
             subplan.getOutputs.toSeq) with CacheByParameter {
 
@@ -83,7 +87,9 @@ class AggregateCompiler extends RoundAwareNodeCompiler {
           new AggregateClassBuilder(
             valueType,
             combinerType,
-            operator)(
+            operator,
+            mapSideCombine =
+              subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
             subPlanInfo.getLabel,
             subplan.getOutputs.toSeq) with CacheOnce
       }

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/aggregation/Aggregation.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/aggregation/Aggregation.scala
@@ -24,8 +24,6 @@ abstract class Aggregation[K, V, C] extends Serializable {
 
   import Aggregation._ // scalastyle:ignore
 
-  def mapSideCombine: Boolean
-
   def newCombiner(): C
 
   def initCombinerByValue(combiner: C, value: V): C

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/fragment/MapGroupView.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/fragment/MapGroupView.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.spark.runtime.fragment
+
+import java.util.{ Iterator => JIterator, List => JList }
+
+import scala.collection.JavaConverters._
+
+import com.asakusafw.runtime.core.GroupView
+
+abstract class MapGroupView[K, V](map: Map[K, Seq[V]]) extends GroupView[V] {
+
+  protected def key(elements: Seq[AnyRef]): K
+
+  override def find(elements: AnyRef*): JList[V] = {
+    map.getOrElse(key(elements), Seq.empty[V]).asJava
+  }
+
+  override def iterator(): JIterator[V] = map.iterator.flatMap(_._2).asJava
+}

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/fragment/user/join/BroadcastJoinOperatorFragment.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/fragment/user/join/BroadcastJoinOperatorFragment.scala
@@ -18,26 +18,26 @@ package user.join
 
 import scala.collection.JavaConverters._
 
+import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.runtime.model.DataModel
 
-abstract class BroadcastJoinOperatorFragment[K, M <: DataModel[M], T <: DataModel[T]](
-  masters: Map[K, Seq[M]])
+abstract class BroadcastJoinOperatorFragment[M <: DataModel[M], T <: DataModel[T]](
+  masters: GroupView[M])
   extends Fragment[T]
   with Join[M, T] {
 
-  def key(tx: T): K
+  protected def keyElements(tx: T): Array[AnyRef]
 
   override def doAdd(tx: T): Unit = {
-    val k = key(tx)
-    val master = masterSelection(masters.getOrElse(k, Seq.empty[M]).asJava, tx)
+    val master = masterSelection(masters.find(keyElements(tx): _*), tx)
     join(master, tx)
   }
 }
 
-abstract class BroadcastMasterBranchOperatorFragment[K, M <: DataModel[M], T <: DataModel[T], E <: Enum[E]]( // scalastyle:ignore
-  masters: Map[K, Seq[M]])(
+abstract class BroadcastMasterBranchOperatorFragment[M <: DataModel[M], T <: DataModel[T], E <: Enum[E]]( // scalastyle:ignore
+  masters: GroupView[M])(
     val children: Map[E, Fragment[T]])
-  extends BroadcastJoinOperatorFragment[K, M, T](masters)
+  extends BroadcastJoinOperatorFragment[M, T](masters)
   with MasterBranch[M, T, E] {
 
   override def doReset(): Unit = {
@@ -45,11 +45,11 @@ abstract class BroadcastMasterBranchOperatorFragment[K, M <: DataModel[M], T <: 
   }
 }
 
-abstract class BroadcastMasterCheckOperatorFragment[K, M <: DataModel[M], T <: DataModel[T]](
-  masters: Map[K, Seq[M]])(
+abstract class BroadcastMasterCheckOperatorFragment[M <: DataModel[M], T <: DataModel[T]](
+  masters: GroupView[M])(
     val missed: Fragment[T],
     val found: Fragment[T])
-  extends BroadcastJoinOperatorFragment[K, M, T](masters)
+  extends BroadcastJoinOperatorFragment[M, T](masters)
   with MasterCheck[M, T] {
 
   override def doReset(): Unit = {
@@ -58,12 +58,12 @@ abstract class BroadcastMasterCheckOperatorFragment[K, M <: DataModel[M], T <: D
   }
 }
 
-abstract class BroadcastMasterJoinOperatorFragment[K, M <: DataModel[M], T <: DataModel[T], J <: DataModel[J]]( // scalastyle:ignore
-  masters: Map[K, Seq[M]])(
+abstract class BroadcastMasterJoinOperatorFragment[M <: DataModel[M], T <: DataModel[T], J <: DataModel[J]]( // scalastyle:ignore
+  masters: GroupView[M])(
     val missed: Fragment[T],
     val joined: Fragment[J],
     val joinedDataModel: J)
-  extends BroadcastJoinOperatorFragment[K, M, T](masters)
+  extends BroadcastJoinOperatorFragment[M, T](masters)
   with MasterJoin[M, T, J] {
 
   override def doReset(): Unit = {
@@ -72,11 +72,11 @@ abstract class BroadcastMasterJoinOperatorFragment[K, M <: DataModel[M], T <: Da
   }
 }
 
-abstract class BroadcastMasterJoinUpdateOperatorFragment[K, M <: DataModel[M], T <: DataModel[T]](
-  masters: Map[K, Seq[M]])(
+abstract class BroadcastMasterJoinUpdateOperatorFragment[M <: DataModel[M], T <: DataModel[T]](
+  masters: GroupView[M])(
     val missed: Fragment[T],
     val updated: Fragment[T])
-  extends BroadcastJoinOperatorFragment[K, M, T](masters)
+  extends BroadcastJoinOperatorFragment[M, T](masters)
   with MasterJoinUpdate[M, T] {
 
   override def doReset(): Unit = {

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/fragment/user/join/BroadcastJoinOperatorFragment.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/fragment/user/join/BroadcastJoinOperatorFragment.scala
@@ -21,10 +21,11 @@ import scala.collection.JavaConverters._
 import com.asakusafw.runtime.core.GroupView
 import com.asakusafw.runtime.model.DataModel
 
-abstract class BroadcastJoinOperatorFragment[M <: DataModel[M], T <: DataModel[T]](
-  masters: GroupView[M])
+abstract class BroadcastJoinOperatorFragment[M <: DataModel[M], T <: DataModel[T]]
   extends Fragment[T]
   with Join[M, T] {
+
+  protected def masters: GroupView[M]
 
   protected def keyElements(tx: T): Array[AnyRef]
 
@@ -35,9 +36,8 @@ abstract class BroadcastJoinOperatorFragment[M <: DataModel[M], T <: DataModel[T
 }
 
 abstract class BroadcastMasterBranchOperatorFragment[M <: DataModel[M], T <: DataModel[T], E <: Enum[E]]( // scalastyle:ignore
-  masters: GroupView[M])(
-    val children: Map[E, Fragment[T]])
-  extends BroadcastJoinOperatorFragment[M, T](masters)
+  val children: Map[E, Fragment[T]])
+  extends BroadcastJoinOperatorFragment[M, T]
   with MasterBranch[M, T, E] {
 
   override def doReset(): Unit = {
@@ -46,10 +46,9 @@ abstract class BroadcastMasterBranchOperatorFragment[M <: DataModel[M], T <: Dat
 }
 
 abstract class BroadcastMasterCheckOperatorFragment[M <: DataModel[M], T <: DataModel[T]](
-  masters: GroupView[M])(
-    val missed: Fragment[T],
-    val found: Fragment[T])
-  extends BroadcastJoinOperatorFragment[M, T](masters)
+  val missed: Fragment[T],
+  val found: Fragment[T])
+  extends BroadcastJoinOperatorFragment[M, T]
   with MasterCheck[M, T] {
 
   override def doReset(): Unit = {
@@ -59,11 +58,10 @@ abstract class BroadcastMasterCheckOperatorFragment[M <: DataModel[M], T <: Data
 }
 
 abstract class BroadcastMasterJoinOperatorFragment[M <: DataModel[M], T <: DataModel[T], J <: DataModel[J]]( // scalastyle:ignore
-  masters: GroupView[M])(
-    val missed: Fragment[T],
-    val joined: Fragment[J],
-    val joinedDataModel: J)
-  extends BroadcastJoinOperatorFragment[M, T](masters)
+  val missed: Fragment[T],
+  val joined: Fragment[J],
+  val joinedDataModel: J)
+  extends BroadcastJoinOperatorFragment[M, T]
   with MasterJoin[M, T, J] {
 
   override def doReset(): Unit = {
@@ -73,10 +71,9 @@ abstract class BroadcastMasterJoinOperatorFragment[M <: DataModel[M], T <: DataM
 }
 
 abstract class BroadcastMasterJoinUpdateOperatorFragment[M <: DataModel[M], T <: DataModel[T]](
-  masters: GroupView[M])(
-    val missed: Fragment[T],
-    val updated: Fragment[T])
-  extends BroadcastJoinOperatorFragment[M, T](masters)
+  val missed: Fragment[T],
+  val updated: Fragment[T])
+  extends BroadcastJoinOperatorFragment[M, T]
   with MasterJoinUpdate[M, T] {
 
   override def doReset(): Unit = {

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Aggregate.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Aggregate.scala
@@ -44,6 +44,8 @@ abstract class Aggregate[V: ClassTag, C: ClassTag](
     jobContext.sparkContext.getConf.getInt(
       Props.FragmentBufferSize, Props.DefaultFragmentBufferSize)
 
+  def mapSideCombine: Boolean
+
   def aggregation(broadcasts: Map[BroadcastId, Broadcasted[_]]): Aggregation[ShuffleKey, V, C]
 
   override protected def doCompute(
@@ -58,7 +60,7 @@ abstract class Aggregate[V: ClassTag, C: ClassTag](
       case (prevs, broadcasts) =>
         withCallSite(rc) {
           val aggregated = {
-            if (aggregation(broadcasts).mapSideCombine) {
+            if (mapSideCombine) {
               val part = Some(partitioner)
               jobContext.sparkContext.confluent(
                 prevs.map { prev =>

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Branching.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Branching.scala
@@ -77,7 +77,7 @@ trait Branching[T] {
             hadoopConf.value, {
               val fragmentsIter = iterateFragments(iter, broadcasts)(fragmentBufferSize)
               val aggs = aggregations(broadcasts)
-              if (aggs.values.exists(_.mapSideCombine)) {
+              if (aggs.nonEmpty) {
                 iterateWithCombiner(fragmentsIter, aggs)
               } else {
                 iterateWithoutCombiner(fragmentsIter)
@@ -108,8 +108,8 @@ trait Branching[T] {
   private def iterateWithCombiner(
     iter: Iterator[(Branch[ShuffleKey], _)],
     aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]]): Iterator[(Branch[ShuffleKey], Array[Byte])] = { // scalastyle:ignore
-    val combiners = aggregations.collect {
-      case (b, agg) if agg.mapSideCombine => b -> agg.valueCombiner()
+    val combiners = aggregations.map {
+      case (b, agg) => b -> agg.valueCombiner()
     }.toMap[BranchKey, Aggregation.Combiner[ShuffleKey, _, _]]
 
     iter.flatMap {

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/rdd/ShuffleKey.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/rdd/ShuffleKey.scala
@@ -46,3 +46,8 @@ class ShuffleKey(
 
   def dropOrdering: ShuffleKey = new ShuffleKey(grouping)
 }
+
+object ShuffleKey {
+
+  val empty: ShuffleKey = new ShuffleKey()
+}

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/aggregation/AggregationSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/aggregation/AggregationSpec.scala
@@ -62,8 +62,6 @@ object AggregationSpec {
 
   class TestAggregation extends Aggregation[Boolean, Int, Seq[Int]] {
 
-    override def mapSideCombine: Boolean = true
-
     override lazy val isSpillEnabled = false
 
     override def newCombiner(): Seq[Int] = {

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/AggregateSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/AggregateSpec.scala
@@ -258,7 +258,7 @@ object AggregateSpec {
       prev: Seq[(Source, BranchKey)],
       sort: Option[SortOrdering],
       part: Partitioner,
-      val aggregation: Aggregation[ShuffleKey, Foo, Foo])(
+      _aggregation: Aggregation[ShuffleKey, Foo, Foo])(
         val label: String)(
           implicit jobContext: JobContext)
       extends Aggregate[Foo, Foo](prev, sort, part)(Map.empty)
@@ -272,13 +272,17 @@ object AggregateSpec {
           label: String)(
             implicit jobContext: JobContext) = this(Seq(prev), sort, part, aggregation)(label)
 
+      override def aggregation(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Aggregation[ShuffleKey, Foo, Foo] = _aggregation
+
       override def branchKeys: Set[BranchKey] = Set(Result)
 
       override def partitioners: Map[BranchKey, Option[Partitioner]] = Map.empty
 
       override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-      override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+      override def aggregations(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
       override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = {
         new ShuffleKey(WritableSerDe.serialize(value.asInstanceOf[Foo].id), Array.emptyByteArray)
@@ -334,7 +338,8 @@ object AggregateSpec {
 
       override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-      override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = {
+      override def aggregations(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = {
         Map(Result1 -> new TestAggregation(true))
       }
 

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/AggregateSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/AggregateSpec.scala
@@ -62,7 +62,7 @@ class AggregateSpec
     numSlices <- Seq(None, Some(8), Some(4))
     mapSideCombine <- Seq(true, false)
   } {
-    val conf = s"numSlices = ${numSlices}, combine = ${mapSideCombine} "
+    val conf = s"numSlices = ${numSlices}, mapSideCombine = ${mapSideCombine} "
 
     it should s"aggregate: [${conf}]" in {
       import TotalAggregate._
@@ -75,10 +75,12 @@ class AggregateSpec
 
       val sort = Option(new SortOrdering())
       val partitioner = new HashPartitioner(2)
-      val aggregation = new TestAggregation(mapSideCombine)
+      val aggregation = new TestAggregation()
 
       val aggregate =
-        new TestAggregate((foos, Input), sort, partitioner, aggregation)("aggregate")
+        new TestAggregate(
+          (foos, Input),
+          sort, partitioner, mapSideCombine, aggregation)("aggregate")
 
       val rc = newRoundContext(batchArguments = Map("bias" -> 0.toString))
 
@@ -107,12 +109,12 @@ class AggregateSpec
 
       val sort = Option(new SortOrdering())
       val partitioner = new HashPartitioner(2)
-      val aggregation = new TestAggregation(mapSideCombine)
+      val aggregation = new TestAggregation()
 
       val aggregate =
         new TestAggregate(
           Seq((foos1, Input), (foos2, Input)),
-          sort, partitioner, aggregation)("aggregate")
+          sort, partitioner, mapSideCombine, aggregation)("aggregate")
 
       val rc = newRoundContext(batchArguments = Map("bias" -> 0.toString))
 
@@ -216,8 +218,7 @@ object AggregateSpec {
     }
   }
 
-  class TestAggregation(val mapSideCombine: Boolean)
-    extends Aggregation[ShuffleKey, Foo, Foo] {
+  class TestAggregation extends Aggregation[ShuffleKey, Foo, Foo] {
 
     override def newCombiner(): Foo = {
       new Foo()
@@ -258,6 +259,7 @@ object AggregateSpec {
       prev: Seq[(Source, BranchKey)],
       sort: Option[SortOrdering],
       part: Partitioner,
+      val mapSideCombine: Boolean,
       _aggregation: Aggregation[ShuffleKey, Foo, Foo])(
         val label: String)(
           implicit jobContext: JobContext)
@@ -268,9 +270,11 @@ object AggregateSpec {
         prev: (Source, BranchKey),
         sort: Option[SortOrdering],
         part: Partitioner,
+        mapSideCombine: Boolean,
         aggregation: Aggregation[ShuffleKey, Foo, Foo])(
           label: String)(
-            implicit jobContext: JobContext) = this(Seq(prev), sort, part, aggregation)(label)
+            implicit jobContext: JobContext) =
+        this(Seq(prev), sort, part, mapSideCombine, aggregation)(label)
 
       override def aggregation(
         broadcasts: Map[BroadcastId, Broadcasted[_]]): Aggregation[ShuffleKey, Foo, Foo] = _aggregation
@@ -340,7 +344,7 @@ object AggregateSpec {
 
       override def aggregations(
         broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = {
-        Map(Result1 -> new TestAggregation(true))
+        Map(Result1 -> new TestAggregation())
       }
 
       override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = {

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/CoGroupSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/CoGroupSpec.scala
@@ -364,7 +364,8 @@ object CoGroupSpec {
 
     override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-    override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+    override def aggregations(
+      broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
     override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = null
 

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/ExtractSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/ExtractSpec.scala
@@ -282,7 +282,8 @@ object ExtractSpec {
 
       override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-      override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+      override def aggregations(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
       override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = null
 
@@ -317,7 +318,8 @@ object ExtractSpec {
 
       override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-      override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+      override def aggregations(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
       override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = null
 
@@ -378,7 +380,8 @@ object ExtractSpec {
       override def orderings: Map[BranchKey, Ordering[ShuffleKey]] =
         Map(Result2 -> new SortOrdering())
 
-      override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+      override def aggregations(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
       override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = {
         val bar = value.asInstanceOf[Bar]

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/InputSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/InputSpec.scala
@@ -314,7 +314,8 @@ object InputSpec {
 
       override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-      override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+      override def aggregations(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
       override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = null
 
@@ -351,7 +352,8 @@ object InputSpec {
 
       override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-      override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+      override def aggregations(
+        broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
       override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = null
 

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/ResourceBrokingIteratorSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/ResourceBrokingIteratorSpec.scala
@@ -140,7 +140,8 @@ object ResourceBrokingIteratorSpec {
 
     override def orderings: Map[BranchKey, Ordering[ShuffleKey]] = Map.empty
 
-    override def aggregations: Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
+    override def aggregations(
+      broadcasts: Map[BroadcastId, Broadcasted[_]]): Map[BranchKey, Aggregation[ShuffleKey, _, _]] = Map.empty
 
     override def shuffleKey(branch: BranchKey, value: Any): ShuffleKey = null
 


### PR DESCRIPTION
## Summary

This PR enables "View API" (asakusafw/asakusafw#700) in Asakusa on Spark.

## Background, Problem or Goal of the patch

See asakusafw/asakusafw#700.

## Design of the fix, or a new feature

In this platform, we implemented view features using broadcast operations.
It may become a limitation for total/max size of views.

Note that `GroupView.find(...)` may raise `IllegalArgumentException` in the following situations:

- the number of key elements is not correct
- each key element type is inconsistent

## Related Issue, Pull Request or Code

- asakusafw/asakusafw#700

## Wanted reviewer

@akirakw, @ashigeru 
