### PR TITLE
Resource pattern of direct output now can accept decimal format.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectOutputPrepareClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectOutputPrepareClassBuilder.scala
@@ -294,18 +294,16 @@ abstract class DirectOutputPrepareGroupClassBuilder(
                                 pushObject(OutputPatternGenerator)
                                 .invokeV("natural", classOf[Fragment].asType,
                                   ldc(segment.getTarget.getName.toMemberName))
-                            case Format.DATE =>
+
+                            case f @ (Format.BYTE | Format.SHORT | Format.INT | Format.LONG
+                              | Format.FLOAT | Format.DOUBLE | Format.DECIMAL
+                              | Format.DATE | Format.DATETIME) =>
                               builder +=
                                 pushObject(OutputPatternGenerator)
-                                .invokeV("date", classOf[Fragment].asType,
+                                .invokeV(f.name.toLowerCase, classOf[Fragment].asType,
                                   ldc(segment.getTarget.getName.toMemberName),
                                   ldc(segment.getArgument))
-                            case Format.DATETIME =>
-                              builder +=
-                                pushObject(OutputPatternGenerator)
-                                .invokeV("dateTime", classOf[Fragment].asType,
-                                  ldc(segment.getTarget.getName.toMemberName),
-                                  ldc(segment.getArgument))
+
                             case _ =>
                               throw new AssertionError(
                                 s"Unknown StringTemplate.Format: ${segment.getFormat}")

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/directio/OutputPatternGeneratorClassBuilderSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/directio/OutputPatternGeneratorClassBuilderSpec.scala
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
+import java.math.{ BigDecimal => JBigDecimal }
 import java.util.Random
 
 import com.asakusafw.lang.compiler.api.testing.MockDataModelLoader
@@ -103,6 +104,125 @@ class OutputPatternGeneratorClassBuilderSpec
       === "p-bar-${arg}")
   }
 
+  it should "compile OutputPatternGenerator byte format" in {
+    val generator = newGenerator(Seq(
+      constant("p-"),
+      byte("byte", "0000")))
+    assert(generator.generate(new Foo(_byte = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "compile OutputPatternGenerator byte format with batch argument" in {
+    val generator = newGenerator(Seq(
+      constant("p-${arg}-"),
+      byte("byte", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_byte = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "compile OutputPatternGenerator short format" in {
+    val generator = newGenerator(Seq(
+      constant("p-"),
+      short("short", "0000")))
+    assert(generator.generate(new Foo(_short = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "compile OutputPatternGenerator short format with batch argument" in {
+    val generator = newGenerator(Seq(
+      constant("p-${arg}-"),
+      short("short", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_short = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "compile OutputPatternGenerator int format" in {
+    val generator = newGenerator(Seq(
+      constant("p-"),
+      int("int", "0000")))
+    assert(generator.generate(new Foo(_int = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "compile OutputPatternGenerator int format with batch argument" in {
+    val generator = newGenerator(Seq(
+      constant("p-${arg}-"),
+      int("int", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_int = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "compile OutputPatternGenerator long format" in {
+    val generator = newGenerator(Seq(
+      constant("p-"),
+      long("long", "0000")))
+    assert(generator.generate(new Foo(_long = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "compile OutputPatternGenerator long format with batch argument" in {
+    val generator = newGenerator(Seq(
+      constant("p-${arg}-"),
+      long("long", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_long = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "compile OutputPatternGenerator float format" in {
+    val generator = newGenerator(Seq(
+      constant("p-"),
+      float("float", "0000")))
+    assert(generator.generate(new Foo(_float = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "compile OutputPatternGenerator float format with batch argument" in {
+    val generator = newGenerator(Seq(
+      constant("p-${arg}-"),
+      float("float", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_float = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "compile OutputPatternGenerator double format" in {
+    val generator = newGenerator(Seq(
+      constant("p-"),
+      double("double", "0000")))
+    assert(generator.generate(new Foo(_double = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "compile OutputPatternGenerator double format with batch argument" in {
+    val generator = newGenerator(Seq(
+      constant("p-${arg}-"),
+      double("double", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_double = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "compile OutputPatternGenerator decimal format" in {
+    val generator = newGenerator(Seq(
+      constant("p-"),
+      decimal("decimal", "0000")))
+    assert(generator.generate(new Foo(_decimal = Some(JBigDecimal.valueOf(1))))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "compile OutputPatternGenerator decimal format with batch argument" in {
+    val generator = newGenerator(Seq(
+      constant("p-${arg}-"),
+      decimal("decimal", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_decimal = Some(JBigDecimal.valueOf(1))))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
   it should "compile OutputPatternGenerator date format" in {
     val generator = newGenerator(Seq(
       constant("p-"),
@@ -123,7 +243,7 @@ class OutputPatternGeneratorClassBuilderSpec
   it should "compile OutputPatternGenerator datetime format" in {
     val generator = newGenerator(Seq(
       constant("p-"),
-      dateTime("dateTime", "yyyyMMdd")))
+      datetime("dateTime", "yyyyMMdd")))
     assert(generator.generate(
       new Foo(_dateTime = Some(new DateTime(2000, 1, 2, 3, 4, 5))))(newStageInfo()).getAsString
       === "p-20000102")
@@ -132,7 +252,7 @@ class OutputPatternGeneratorClassBuilderSpec
   it should "compile OutputPatternGenerator datetime format with batch argument" in {
     val generator = newGenerator(Seq(
       constant("p-${arg}-"),
-      dateTime("dateTime", "yyyyMMdd")))
+      datetime("dateTime", "yyyyMMdd")))
     val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
     assert(generator.generate(
       new Foo(_dateTime = Some(new DateTime(2000, 1, 2, 3, 4, 5))))(stageInfo).getAsString
@@ -144,29 +264,71 @@ object OutputPatternGeneratorClassBuilderSpec {
 
   class Foo(
     _str: Option[String] = None,
+    _byte: Option[Byte] = None,
+    _short: Option[Short] = None,
+    _int: Option[Int] = None,
+    _long: Option[Long] = None,
+    _float: Option[Float] = None,
+    _double: Option[Double] = None,
+    _decimal: Option[JBigDecimal] = None,
     _date: Option[Date] = None,
     _dateTime: Option[DateTime] = None) extends DataModel[Foo] {
 
     val str: StringOption = new StringOption()
+    val byte: ByteOption = new ByteOption()
+    val short: ShortOption = new ShortOption()
+    val int: IntOption = new IntOption()
+    val long: LongOption = new LongOption()
+    val float: FloatOption = new FloatOption()
+    val double: DoubleOption = new DoubleOption()
+    val decimal: DecimalOption = new DecimalOption()
     val date: DateOption = new DateOption()
     val dateTime: DateTimeOption = new DateTimeOption()
 
     _str.foreach(str.modify)
+    _byte.foreach(byte.modify)
+    _short.foreach(short.modify)
+    _int.foreach(int.modify)
+    _long.foreach(long.modify)
+    _float.foreach(float.modify)
+    _double.foreach(double.modify)
+    _decimal.foreach(decimal.modify)
     _date.foreach(date.modify)
     _dateTime.foreach(dateTime.modify)
 
     override def reset(): Unit = {
       str.setNull()
+      byte.setNull()
+      short.setNull()
+      int.setNull()
+      long.setNull()
+      float.setNull()
+      double.setNull()
+      decimal.setNull()
       date.setNull()
       dateTime.setNull()
     }
     override def copyFrom(other: Foo): Unit = {
       str.copyFrom(other.str)
+      byte.copyFrom(other.byte)
+      short.copyFrom(other.short)
+      int.copyFrom(other.int)
+      long.copyFrom(other.long)
+      float.copyFrom(other.float)
+      double.copyFrom(other.double)
+      decimal.copyFrom(other.decimal)
       date.copyFrom(other.date)
       dateTime.copyFrom(other.dateTime)
     }
 
     def getStrOption(): StringOption = str
+    def getByteOption(): ByteOption = byte
+    def getShortOption(): ShortOption = short
+    def getIntOption(): IntOption = int
+    def getLongOption(): LongOption = long
+    def getFloatOption(): FloatOption = float
+    def getDoubleOption(): DoubleOption = double
+    def getDecimalOption(): DecimalOption = decimal
     def getDateOption(): DateOption = date
     def getDateTimeOption(): DateTimeOption = dateTime
   }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareEachForIterativeClassBuilder.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareEachForIterativeClassBuilder.scala
@@ -257,18 +257,16 @@ abstract class DirectOutputPrepareGroupEachForIterativeClassBuilder(
                                 pushObject(OutputPatternGenerator)
                                 .invokeV("natural", classOf[Fragment].asType,
                                   ldc(segment.getTarget.getName.toMemberName))
-                            case Format.DATE =>
+
+                            case f @ (Format.BYTE | Format.SHORT | Format.INT | Format.LONG
+                              | Format.FLOAT | Format.DOUBLE | Format.DECIMAL
+                              | Format.DATE | Format.DATETIME) =>
                               builder +=
                                 pushObject(OutputPatternGenerator)
-                                .invokeV("date", classOf[Fragment].asType,
+                                .invokeV(f.name.toLowerCase, classOf[Fragment].asType,
                                   ldc(segment.getTarget.getName.toMemberName),
                                   ldc(segment.getArgument))
-                            case Format.DATETIME =>
-                              builder +=
-                                pushObject(OutputPatternGenerator)
-                                .invokeV("dateTime", classOf[Fragment].asType,
-                                  ldc(segment.getTarget.getName.toMemberName),
-                                  ldc(segment.getArgument))
+
                             case _ =>
                               throw new AssertionError(
                                 s"Unknown StringTemplate.Format: ${segment.getFormat}")

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/directio/OutputPatternGeneratorSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/directio/OutputPatternGeneratorSpec.scala
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
+import java.math.{ BigDecimal => JBigDecimal }
 import java.util.Random
 
 import com.asakusafw.runtime.value._
@@ -83,6 +84,125 @@ class OutputPatternGeneratorSpec extends FlatSpec with StageInfoSugar {
       === "p-bar-${arg}")
   }
 
+  it should "generate byte format" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-"),
+      byte("byte", "0000")))
+    assert(generator.generate(new Foo(_byte = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "generate byte format with batch argument" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-${arg}-"),
+      byte("byte", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_byte = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "generate short format" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-"),
+      short("short", "0000")))
+    assert(generator.generate(new Foo(_short = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "generate short format with batch argument" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-${arg}-"),
+      short("short", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_short = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "generate int format" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-"),
+      int("int", "0000")))
+    assert(generator.generate(new Foo(_int = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "generate int format with batch argument" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-${arg}-"),
+      int("int", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_int = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "generate long format" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-"),
+      long("long", "0000")))
+    assert(generator.generate(new Foo(_long = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "generate long format with batch argument" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-${arg}-"),
+      long("long", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_long = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "generate float format" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-"),
+      float("float", "0000")))
+    assert(generator.generate(new Foo(_float = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "generate float format with batch argument" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-${arg}-"),
+      float("float", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_float = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "generate double format" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-"),
+      double("double", "0000")))
+    assert(generator.generate(new Foo(_double = Some(1)))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "generate double format with batch argument" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-${arg}-"),
+      double("double", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_double = Some(1)))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
+  it should "generate decimal format" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-"),
+      decimal("decimal", "0000")))
+    assert(generator.generate(new Foo(_decimal = Some(JBigDecimal.valueOf(1))))(newStageInfo()).getAsString
+      === "p-0001")
+  }
+
+  it should "generate decimal format with batch argument" in {
+    val generator = new FooOutputPatternGenerator(Seq(
+      constant("p-${arg}-"),
+      decimal("decimal", "0000")))
+    val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
+    assert(generator.generate(new Foo(_decimal = Some(JBigDecimal.valueOf(1))))(stageInfo).getAsString
+      === "p-bar-0001")
+  }
+
   it should "generate date format" in {
     val generator = new FooOutputPatternGenerator(Seq(
       constant("p-"),
@@ -103,7 +223,7 @@ class OutputPatternGeneratorSpec extends FlatSpec with StageInfoSugar {
   it should "generate datetime format" in {
     val generator = new FooOutputPatternGenerator(Seq(
       constant("p-"),
-      dateTime("dateTime", "yyyyMMdd")))
+      datetime("dateTime", "yyyyMMdd")))
     assert(generator.generate(
       new Foo(_dateTime = Some(new DateTime(2000, 1, 2, 3, 4, 5))))(newStageInfo()).getAsString
       === "p-20000102")
@@ -112,7 +232,7 @@ class OutputPatternGeneratorSpec extends FlatSpec with StageInfoSugar {
   it should "generate datetime format with batch argument" in {
     val generator = new FooOutputPatternGenerator(Seq(
       constant("p-${arg}-"),
-      dateTime("dateTime", "yyyyMMdd")))
+      datetime("dateTime", "yyyyMMdd")))
     val stageInfo = newStageInfo(batchArguments = Map("arg" -> "bar"))
     assert(generator.generate(
       new Foo(_dateTime = Some(new DateTime(2000, 1, 2, 3, 4, 5))))(stageInfo).getAsString
@@ -124,14 +244,35 @@ object OutputPatternGeneratorSpec {
 
   class Foo(
     _str: Option[String] = None,
+    _byte: Option[Byte] = None,
+    _short: Option[Short] = None,
+    _int: Option[Int] = None,
+    _long: Option[Long] = None,
+    _float: Option[Float] = None,
+    _double: Option[Double] = None,
+    _decimal: Option[JBigDecimal] = None,
     _date: Option[Date] = None,
     _dateTime: Option[DateTime] = None) {
 
     val str: StringOption = new StringOption()
+    val byte: ByteOption = new ByteOption()
+    val short: ShortOption = new ShortOption()
+    val int: IntOption = new IntOption()
+    val long: LongOption = new LongOption()
+    val float: FloatOption = new FloatOption()
+    val double: DoubleOption = new DoubleOption()
+    val decimal: DecimalOption = new DecimalOption()
     val date: DateOption = new DateOption()
     val dateTime: DateTimeOption = new DateTimeOption()
 
     _str.foreach(str.modify)
+    _byte.foreach(byte.modify)
+    _short.foreach(short.modify)
+    _int.foreach(int.modify)
+    _long.foreach(long.modify)
+    _float.foreach(float.modify)
+    _double.foreach(double.modify)
+    _decimal.foreach(decimal.modify)
     _date.foreach(date.modify)
     _dateTime.foreach(dateTime.modify)
   }
@@ -142,6 +283,13 @@ object OutputPatternGeneratorSpec {
     override def getProperty(foo: Foo, property: String): ValueOption[_] = {
       property match {
         case "str" => foo.str
+        case "byte" => foo.byte
+        case "short" => foo.short
+        case "int" => foo.int
+        case "long" => foo.long
+        case "float" => foo.float
+        case "double" => foo.double
+        case "decimal" => foo.decimal
         case "date" => foo.date
         case "dateTime" => foo.dateTime
       }


### PR DESCRIPTION
## Summary

Resource pattern of Direct I/O file output now can accept decimal format (DecimalFormat).

## Background, Problem or Goal of the patch

This is asakusafw/asakusafw#719 implementation for Asakusa on Spark.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

- asakusafw/asakusafw#719

## Wanted reviewer

@akirakw, @ashigeru 
