### PR TITLE
Fix bug with an empty input to cogroup operator

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/CoGroupInstantiator.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/CoGroupInstantiator.scala
@@ -83,9 +83,14 @@ object CoGroupInstantiator extends Instantiator {
       if (properties.head.isEmpty) {
         partitioner(ldc(1))
       } else {
-        partitioner(
-          numPartitions(vars.jobContext.push())(
-            subplan.findInput(primaryOperator.inputs.head.getOpposites.head.getOwner)))
+        primaryOperator.inputs.find(op => op.getOpposites.nonEmpty) match {
+          case Some(operator) =>
+            partitioner(
+              numPartitions(vars.jobContext.push())(
+                subplan.findInput(operator.getOpposites.head.getOwner)))
+          case None =>
+            throw new AssertionError(s"All inputs have empty opposites for ${primaryOperator}.")
+        }
       },
       vars.broadcasts.push(),
       vars.jobContext.push())


### PR DESCRIPTION
## Summary

When the first input port of CoGroup is empty (`core.empty`), compiler fails with the exception [1].

## Background, Problem or Goal of the patch

To estimate data size (therefore partitions), the first input port is used before this patch.
When the port is empty (hence no opposites), the calculation emits the exception.

## Design of the fix, or a new feature

Instead of using head of input ports to the CoGroup operator, the first _non-empty_ port
is adopted. Then the first port can be empty.

## Related Issue, Pull Request or Code

N/A

## Wanted reviewer

@ashigeru 

-------------

[1] The exception stack trace is like this:

```
java.util.NoSuchElementException: null
        at java.util.ArrayList$Itr.next(ArrayList.java:854)
        at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1042)
        at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:43)
        at scala.collection.IterableLike$class.head(IterableLike.scala:107)
        at scala.collection.AbstractIterable.head(Iterable.scala:54)
        at com.asakusafw.spark.compiler.graph.CoGroupInstantiator$$anonfun$newInstance$4.apply(CoGroupInstantiator.scala:88)
        at com.asakusafw.spark.compiler.graph.CoGroupInstantiator$$anonfun$newInstance$4.apply(CoGroupInstantiator.scala:87)
        at com.asakusafw.spark.compiler.util.SparkIdioms$.partitioner(SparkIdioms.scala:38)
        at com.asakusafw.spark.compiler.graph.CoGroupInstantiator$.newInstance(CoGroupInstantiator.scala:86)
        at com.asakusafw.spark.compiler.graph.JobClassBuilder$$anonfun$com$asakusafw$spark$compiler$graph$JobClassBuilder$$defNode$1.apply(JobClassBuilder.scala:279)
        at com.asakusafw.spark.compiler.graph.JobClassBuilder$$anonfun$com$asakusafw$spark$compiler$graph$JobClassBuilder$$defNode$1.apply(JobClassBuilder.scala:228)
        at com.asakusafw.spark.tools.asm.ClassBuilder$MethodDef.newMethod(ClassBuilder.scala:554)
        at com.asakusafw.spark.tools.asm.ClassBuilder$MethodDef.newMethod(ClassBuilder.scala:454)
        at com.asakusafw.spark.tools.asm.ClassBuilder$MethodDef.newMethod(ClassBuilder.scala:398)
        at com.asakusafw.spark.compiler.graph.JobClassBuilder.com$asakusafw$spark$compiler$graph$JobClassBuilder$$defNode(JobClassBuilder.scala:228)
        at com.asakusafw.spark.compiler.graph.JobClassBuilder$$anonfun$defMethods$3.apply(JobClassBuilder.scala:148)
        at com.asakusafw.spark.compiler.graph.JobClassBuilder$$anonfun$defMethods$3.apply(JobClassBuilder.scala:147)
        at scala.collection.Iterator$class.foreach(Iterator.scala:893)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
        at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
        at com.asakusafw.spark.compiler.graph.JobClassBuilder.defMethods(JobClassBuilder.scala:147)
```