### PR TITLE
Fix views in co-group kind operators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ target
 dependency-reduced-pom.xml
 *.crc
 .tmpBin
+
+# IntelliJ IDEA
+.idea
+*.iml
+

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/CoGroupInstantiator.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/CoGroupInstantiator.scala
@@ -41,7 +41,7 @@ object CoGroupInstantiator extends Instantiator {
 
     val primaryOperator = subplan.getAttribute(classOf[SubPlanInfo]).getPrimaryOperator
 
-    val properties = primaryOperator.inputs.map { input =>
+    val properties = primaryOperator.nonBroadcastInputs.map { input =>
       input.dataModelRef.groupingTypes(input.getGroup.getGrouping)
     }.toSet
     assert(properties.size == 1,
@@ -53,7 +53,7 @@ object CoGroupInstantiator extends Instantiator {
     cogroup.dup().invokeInit(
       buildSeq { builder =>
         for {
-          input <- primaryOperator.getInputs
+          input <- primaryOperator.nonBroadcastInputs
         } {
           builder +=
             tuple2(
@@ -83,7 +83,7 @@ object CoGroupInstantiator extends Instantiator {
       if (properties.head.isEmpty) {
         partitioner(ldc(1))
       } else {
-        primaryOperator.inputs.find(op => op.getOpposites.nonEmpty) match {
+        primaryOperator.nonBroadcastInputs.find(op => op.getOpposites.nonEmpty) match {
           case Some(operator) =>
             partitioner(
               numPartitions(vars.jobContext.push())(

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/package.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/package.scala
@@ -124,6 +124,10 @@ package object compiler {
       operator.getArguments
     }
 
+    def nonBroadcastInputs: Seq[OperatorInput] = {
+      operator.inputs.filter(_.getInputUnit != OperatorInput.InputUnit.WHOLE)
+    }
+
     def branchOutputMap(
       implicit provider: ClassLoaderProvider): Map[OperatorOutput, Enum[_]] = {
       BranchOperatorUtil.getOutputMap(provider.classLoader, operator).toMap


### PR DESCRIPTION
## Summary

This PR fixes views in co-group kind operators (e.g. `@CoGroup`), on DSL compiler for Spark.

## Background, Problem or Goal of the patch

This is a similar bug with asakusafw/asakusafw-compiler#131 for Asakusa on Spark. 

Using views with co-group kind operators,  will be crashed with the following message:

```
Exception in thread "main" java.lang.AssertionError: assertion failed: The grouping of all inputs should be the same: (snip)
    at scala.Predef$.assert(Predef.scala:170)
    at com.asakusafw.spark.compiler.graph.CoGroupInstantiator$.newInstance(CoGroupInstantiator.scala:47)
(snip)
```

## Design of the fix, or a new feature

`CoGroupInstantiator.scala` verifies primary operator of co-group kind sub-plans whose inputs have valid keys for partitioning operations. But it validation includes not only primary inputs of the operator, but broadcast inputs. This PR removes broadcast inputs for computing partition keys.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#131