### PR TITLE
Avoid using deprecated methods since Gradle 4.0.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -74,6 +74,19 @@ tasks.withType(AbstractCompile) { task ->
 eclipse.jdt {
     javaRuntimeName = 'JavaSE-1.7'
 }
+if (project.hasProperty('referProject')) {
+    eclipse.classpath.file.whenMerged { classpath ->
+        classpath.entries = classpath.entries.collect { entry ->
+            if (entry instanceof org.gradle.plugins.ide.eclipse.model.Library \
+                    && entry.moduleVersion \
+                    && entry.moduleVersion.name == 'asakusa-gradle-plugins') {
+                new org.gradle.plugins.ide.eclipse.model.ProjectDependency('/asakusa-gradle-plugins')
+            } else {
+                entry
+            }
+        }.unique() as List
+    }
+}
 
 groovydoc {
     docTitle "Asakusa on Spark Gradle Plugins ${version}"

--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPlugin.groovy
@@ -91,7 +91,7 @@ class AsakusaSparkSdkPlugin implements Plugin<Project> {
             task.toolClasspath << { project.configurations.asakusaSparkCompiler }
             task.toolClasspath << { project.sourceSets.main.compileClasspath - project.configurations.compile }
 
-            task.explore << { [project.sourceSets.main.output.classesDir].findAll { it.exists() } }
+            task.explore << { PluginUtils.getClassesDirs(project, project.sourceSets.main.output).findAll { it.exists() } }
             task.embed << { [project.sourceSets.main.output.resourcesDir].findAll { it.exists() } }
             task.attach << { project.configurations.embedded }
 


### PR DESCRIPTION
## Summary

This PR replaces uses of Gradle API which will be deprecated since Gradle 4.0.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw-sdk#138.

## Design of the fix, or a new feature

This suppresses warnings on building Asakusa projects with `asakusafw-spark` plugin.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-sdk#138
