### PR TITLE
Direct file output attempt must not ignore errors.

### DIFF
--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/DirectOutputPrepare.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/DirectOutputPrepare.scala
@@ -146,6 +146,7 @@ abstract class DirectOutputPrepare[T: Manifest](
           "error occurred while processing Direct file output: " +
             s"basePath=${basePath}, context=${context}",
           t)
+        throw t
     } finally {
       dataSource.cleanupAttemptOutput(context)
     }


### PR DESCRIPTION
## Summary

Direct I/O file outputs in Asakusa on Spark sometimes ignore errors on committing attempt outputs, and then job will successfully finish even if some outputs would be lost.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This PR fixes to re-throw occurred exceptions while committing attempt outputs.

## Related Issue, Pull Request or Code

N/A.