### PR TITLE
Don't ignore null values on `max` in summarize operator.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/operator/aggregation/SummarizeAggregationCompiler.scala
@@ -18,13 +18,12 @@ package operator
 package aggregation
 
 import scala.collection.JavaConversions._
-
 import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 import org.objectweb.asm.Type
 import org.objectweb.asm.signature.SignatureVisitor
-
 import com.asakusafw.lang.compiler.analyzer.util.{ PropertyFolding, SummarizedModelUtil }
 import com.asakusafw.lang.compiler.model.graph.UserOperator
+import com.asakusafw.runtime.value.ValueOption
 import com.asakusafw.spark.compiler.spi.AggregationCompiler
 import com.asakusafw.spark.runtime.graph.BroadcastId
 import com.asakusafw.spark.runtime.util.ValueOptionOps
@@ -106,13 +105,27 @@ private class SummarizeAggregationClassBuilder(
       folding.getAggregation match {
         case PropertyFolding.Aggregation.ANY =>
           pushObject(ValueOptionOps)
-            .invokeV("copy",
-              valueVar.push().invokeV(
-                valuePropertyRef.getDeclaration.getName,
-                valuePropertyRef.getType.asType),
+            .invokeV("copyAlways",
               combinerVar.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType))
+                combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
+              valueVar.push().invokeV(
+                valuePropertyRef.getDeclaration.getName,
+                valuePropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType))
+          // 'any' merges nothing
+
+        case PropertyFolding.Aggregation.MAX | PropertyFolding.Aggregation.MIN =>
+          pushObject(ValueOptionOps)
+            .invokeV("copyWithName",
+              combinerVar.push().invokeV(
+                combinerPropertyRef.getDeclaration.getName,
+                combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
+              valueVar.push().invokeV(
+                valuePropertyRef.getDeclaration.getName,
+                valuePropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
+              ldc(getOperandName(folding)),
+              valueVar.push().asType(classOf[AnyRef].asType))
+          // always {max,min}(a, a) = a
 
         case PropertyFolding.Aggregation.SUM =>
           pushObject(ValueOptionOps)
@@ -120,6 +133,7 @@ private class SummarizeAggregationClassBuilder(
               combinerVar.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
                 combinerPropertyRef.getType.asType))
+          generateMergeValueStatement(folding, combinerVar, valueVar)
 
         case PropertyFolding.Aggregation.COUNT =>
           pushObject(ValueOptionOps)
@@ -127,67 +141,91 @@ private class SummarizeAggregationClassBuilder(
               combinerVar.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
                 combinerPropertyRef.getType.asType))
+          generateMergeValueStatement(folding, combinerVar, valueVar)
 
         case _ => // NoOP
       }
     }
-    `return`(
-      thisVar.push().invokeV("mergeValue", combinerType, combinerVar.push(), valueVar.push()))
+    `return`(combinerVar.push())
   }
 
   override def defMergeValue(
     combinerVar: Var, valueVar: Var)(
       implicit mb: MethodBuilder): Unit = {
     propertyFoldings.foreach { folding =>
-      val mapping = folding.getMapping
-      val valuePropertyRef =
-        operator.inputs(Summarize.ID_INPUT)
-          .dataModelRef.findProperty(mapping.getSourceProperty)
-      val combinerPropertyRef =
-        operator.outputs(Summarize.ID_OUTPUT)
-          .dataModelRef.findProperty(mapping.getDestinationProperty)
-      folding.getAggregation match {
-        case PropertyFolding.Aggregation.SUM =>
-          pushObject(ValueOptionOps)
-            .invokeV("add",
-              valueVar.push().invokeV(
-                valuePropertyRef.getDeclaration.getName,
-                valuePropertyRef.getType.asType),
-              combinerVar.push().invokeV(
-                combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType))
-
-        case PropertyFolding.Aggregation.MAX =>
-          pushObject(ValueOptionOps)
-            .invokeV("max",
-              combinerVar.push().invokeV(
-                combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType),
-              valueVar.push().invokeV(
-                valuePropertyRef.getDeclaration.getName,
-                valuePropertyRef.getType.asType))
-
-        case PropertyFolding.Aggregation.MIN =>
-          pushObject(ValueOptionOps)
-            .invokeV("min",
-              combinerVar.push().invokeV(
-                combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType),
-              valueVar.push().invokeV(
-                valuePropertyRef.getDeclaration.getName,
-                valuePropertyRef.getType.asType))
-
-        case PropertyFolding.Aggregation.COUNT =>
-          pushObject(ValueOptionOps)
-            .invokeV("inc",
-              combinerVar.push().invokeV(
-                combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType))
-
-        case _ => // NoOP
-      }
+      generateMergeValueStatement(folding, combinerVar, valueVar)
     }
     `return`(combinerVar.push())
+  }
+
+  private[this] def getOperandName(folding: PropertyFolding): String = {
+    val property =
+      operator.inputs(Summarize.ID_INPUT)
+        .dataModelRef.findProperty(folding.getMapping.getSourceProperty)
+    "@%s:%s.%s(%s.%s)".format(
+      operator.getAnnotation.getDeclaringClass.getSimpleName,
+      operator.getMethod.getDeclaringClass.getClassName,
+      operator.getMethod.getName,
+      property.getOwner.getDeclaration.getSimpleName,
+      property.getName.toName)
+  }
+
+  private[this] def generateMergeValueStatement(
+    folding: PropertyFolding, combinerVar: Var, valueVar: Var)(
+      implicit mb: MethodBuilder): Unit = {
+    val mapping = folding.getMapping
+    val valuePropertyRef =
+      operator.inputs(Summarize.ID_INPUT)
+        .dataModelRef.findProperty(mapping.getSourceProperty)
+    val combinerPropertyRef =
+      operator.outputs(Summarize.ID_OUTPUT)
+        .dataModelRef.findProperty(mapping.getDestinationProperty)
+    folding.getAggregation match {
+      case PropertyFolding.Aggregation.SUM =>
+        pushObject(ValueOptionOps)
+          .invokeV("addWithName",
+            combinerVar.push().invokeV(
+              combinerPropertyRef.getDeclaration.getName,
+              combinerPropertyRef.getType.asType),
+            valueVar.push().invokeV(
+              valuePropertyRef.getDeclaration.getName,
+              valuePropertyRef.getType.asType),
+            ldc(getOperandName(folding)),
+            valueVar.push().asType(classOf[AnyRef].asType))
+
+      case PropertyFolding.Aggregation.MAX =>
+        pushObject(ValueOptionOps)
+          .invokeV("maxWithName",
+            combinerVar.push().invokeV(
+              combinerPropertyRef.getDeclaration.getName,
+              combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
+            valueVar.push().invokeV(
+              valuePropertyRef.getDeclaration.getName,
+              valuePropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
+            ldc(getOperandName(folding)),
+            valueVar.push().asType(classOf[AnyRef].asType))
+
+      case PropertyFolding.Aggregation.MIN =>
+        pushObject(ValueOptionOps)
+          .invokeV("minWithName",
+            combinerVar.push().invokeV(
+              combinerPropertyRef.getDeclaration.getName,
+              combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
+            valueVar.push().invokeV(
+              valuePropertyRef.getDeclaration.getName,
+              valuePropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
+            ldc(getOperandName(folding)),
+            valueVar.push().asType(classOf[AnyRef].asType))
+
+      case PropertyFolding.Aggregation.COUNT =>
+        pushObject(ValueOptionOps)
+          .invokeV("inc",
+            combinerVar.push().invokeV(
+              combinerPropertyRef.getDeclaration.getName,
+              combinerPropertyRef.getType.asType))
+
+      case _ => // NoOP
+    }
   }
 
   override def defInitCombinerByCombiner(
@@ -204,45 +242,35 @@ private class SummarizeAggregationClassBuilder(
         operator.outputs(Summarize.ID_OUTPUT)
           .dataModelRef.findProperty(mapping.getDestinationProperty)
       folding.getAggregation match {
-        case PropertyFolding.Aggregation.SUM =>
+        case PropertyFolding.Aggregation.SUM | PropertyFolding.Aggregation.COUNT =>
           pushObject(ValueOptionOps)
-            .invokeV("add",
-              comb2Var.push().invokeV(
+            .invokeV("addUnsafe",
+              comb1Var.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
                 combinerPropertyRef.getType.asType),
-              comb1Var.push().invokeV(
+              comb2Var.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
                 combinerPropertyRef.getType.asType))
 
         case PropertyFolding.Aggregation.MAX =>
           pushObject(ValueOptionOps)
-            .invokeV("max",
+            .invokeV("maxUnsafe",
               comb1Var.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType),
+                combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
               comb2Var.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType))
+                combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType))
 
         case PropertyFolding.Aggregation.MIN =>
           pushObject(ValueOptionOps)
-            .invokeV("min",
+            .invokeV("minUnsafe",
               comb1Var.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType),
+                combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType),
               comb2Var.push().invokeV(
                 combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType))
-
-        case PropertyFolding.Aggregation.COUNT =>
-          pushObject(ValueOptionOps)
-            .invokeV("add",
-              comb2Var.push().invokeV(
-                combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType),
-              comb1Var.push().invokeV(
-                combinerPropertyRef.getDeclaration.getName,
-                combinerPropertyRef.getType.asType))
+                combinerPropertyRef.getType.asType).asType(classOf[ValueOption[_]].asType))
 
         case _ => // NoOP
       }

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/util/ValueOptionOps.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/util/ValueOptionOps.scala
@@ -18,6 +18,8 @@ package com.asakusafw.spark.runtime.util
 import com.asakusafw.runtime.value._
 import com.asakusafw.spark.runtime.orderings._
 
+import scala.tools.cmd.Spec.Accumulator
+
 object ValueOptionOps {
 
   def copy(from: BooleanOption, to: BooleanOption): Unit = {
@@ -73,170 +75,117 @@ object ValueOptionOps {
   }
 
   def setZero(to: DecimalOption): Unit = {
-    to.modify(BigDecimal(0).underlying)
+    to.modify(java.math.BigDecimal.ZERO)
   }
 
   def inc(to: LongOption): Unit = {
     to.add(1L)
   }
 
-  def add(value: ByteOption, acc: LongOption): Unit = {
-    acc.add(value.get)
+  def copyAlways[V <: ValueOption[V]](accumulator: V, operand: V): Unit = {
+    accumulator.copyFrom(operand)
   }
 
-  def add(value: ShortOption, acc: LongOption): Unit = {
-    acc.add(value.get)
+  def maxUnsafe[V <: ValueOption[V]](accumulator: V, operand: V): Unit = {
+    accumulator.max(operand)
   }
 
-  def add(value: IntOption, acc: LongOption): Unit = {
-    acc.add(value.get)
+  def minUnsafe[V <: ValueOption[V]](accumulator: V, operand: V): Unit = {
+    accumulator.min(operand)
   }
 
-  def add(value: LongOption, acc: LongOption): Unit = {
-    acc.add(value.get)
+  def addUnsafe(accumulator: LongOption, operand: ByteOption): Unit = {
+    accumulator.add(operand.get())
   }
 
-  def add(value: FloatOption, acc: DoubleOption): Unit = {
-    acc.add(value.get)
+  def addUnsafe(accumulator: LongOption, operand: ShortOption): Unit = {
+    accumulator.add(operand.get())
   }
 
-  def add(value: DoubleOption, acc: DoubleOption): Unit = {
-    acc.add(value.get)
+  def addUnsafe(accumulator: LongOption, operand: IntOption): Unit = {
+    accumulator.add(operand.get())
   }
 
-  def add(value: DecimalOption, acc: DecimalOption): Unit = {
-    acc.add(value.get)
+  def addUnsafe(accumulator: LongOption, operand: LongOption): Unit = {
+    accumulator.add(operand)
   }
 
-  def max(combiner: BooleanOption, value: BooleanOption): Unit = {
-    if (combiner.isNull || BooleanOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addUnsafe(accumulator: DecimalOption, operand: DecimalOption): Unit = {
+    accumulator.add(operand)
   }
 
-  def max(combiner: ByteOption, value: ByteOption): Unit = {
-    if (combiner.isNull || ByteOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addUnsafe(accumulator: DoubleOption, operand: FloatOption): Unit = {
+    accumulator.add(operand.get())
   }
 
-  def max(combiner: ShortOption, value: ShortOption): Unit = {
-    if (combiner.isNull || ShortOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addUnsafe(accumulator: DoubleOption, operand: DoubleOption): Unit = {
+    accumulator.add(operand)
   }
 
-  def max(combiner: IntOption, value: IntOption): Unit = {
-    if (combiner.isNull || IntOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def copyWithName[V <: ValueOption[V]](
+    accumulator: V, operand: V, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.copyFrom(operand)
   }
 
-  def max(combiner: LongOption, value: LongOption): Unit = {
-    if (combiner.isNull || LongOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def maxWithName[V <: ValueOption[V]](
+    accumulator: V, operand: V, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.max(operand)
   }
 
-  def max(combiner: FloatOption, value: FloatOption): Unit = {
-    if (combiner.isNull || FloatOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def minWithName[V <: ValueOption[V]](
+    accumulator: V, operand: V, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.min(operand)
   }
 
-  def max(combiner: DoubleOption, value: DoubleOption): Unit = {
-    if (combiner.isNull || DoubleOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addWithName(
+    accumulator: LongOption, operand: ByteOption, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.add(operand.get())
   }
 
-  def max(combiner: DecimalOption, value: DecimalOption): Unit = {
-    if (combiner.isNull || DecimalOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addWithName(
+    accumulator: LongOption, operand: ShortOption, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.add(operand.get())
   }
 
-  def max(combiner: StringOption, value: StringOption): Unit = {
-    if (combiner.isNull || StringOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addWithName(
+    accumulator: LongOption, operand: IntOption, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.add(operand.get())
   }
 
-  def max(combiner: DateOption, value: DateOption): Unit = {
-    if (combiner.isNull || DateOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addWithName(
+    accumulator: LongOption, operand: LongOption, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.add(operand)
   }
 
-  def max(combiner: DateTimeOption, value: DateTimeOption): Unit = {
-    if (combiner.isNull || DateTimeOptionOrdering.compare(combiner, value) < 0) {
-      combiner.modify(value.get)
-    }
+  def addWithName(
+    accumulator: DecimalOption, operand: DecimalOption, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.add(operand)
   }
 
-  def min(combiner: BooleanOption, value: BooleanOption): Unit = {
-    if (combiner.isNull || BooleanOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
+  def addWithName(
+    accumulator: DoubleOption, operand: FloatOption, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.add(operand.get())
   }
 
-  def min(combiner: ByteOption, value: ByteOption): Unit = {
-    if (combiner.isNull || ByteOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
+  def addWithName(
+    accumulator: DoubleOption, operand: DoubleOption, name: String, record: AnyRef): Unit = {
+    checkNull(operand, name, record)
+    accumulator.add(operand)
   }
 
-  def min(combiner: ShortOption, value: ShortOption): Unit = {
-    if (combiner.isNull || ShortOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: IntOption, value: IntOption): Unit = {
-    if (combiner.isNull || IntOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: LongOption, value: LongOption): Unit = {
-    if (combiner.isNull || LongOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: FloatOption, value: FloatOption): Unit = {
-    if (combiner.isNull || FloatOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: DoubleOption, value: DoubleOption): Unit = {
-    if (combiner.isNull || DoubleOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: DecimalOption, value: DecimalOption): Unit = {
-    if (combiner.isNull || DecimalOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: StringOption, value: StringOption): Unit = {
-    if (combiner.isNull || StringOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: DateOption, value: DateOption): Unit = {
-    if (combiner.isNull || DateOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
-    }
-  }
-
-  def min(combiner: DateTimeOption, value: DateTimeOption): Unit = {
-    if (combiner.isNull || DateTimeOptionOrdering.compare(combiner, value) > 0) {
-      combiner.modify(value.get)
+  private[this] def checkNull(operand: ValueOption[_], name: String, record: AnyRef): Unit = {
+    if (operand.isNull) {
+      throw new NullPointerException(
+        s"${name} must not be null: ${record}")
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR ensures to raise NPE for null values on `@Summarize` operators.

## Background, Problem or Goal of the patch

The latest implementation sometimes ignores null values on `max` operation.

## Design of the fix, or a new feature

This also revises error messages of NPE on `@Summarize` operators. It message will include operator method name, data model properties, and content of erroneous object.

## Related Issue, Pull Request or Code

N/A.
