### PR TITLE
Enable identify the processing stages in Spark.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/SparkClientCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/SparkClientCompiler.scala
@@ -74,6 +74,8 @@ class SparkClientCompiler extends JobflowProcessor {
 
     val plan = preparePlan(jpContext, source)
 
+    SparkPlanning.saveInfo(jpContext, plan)
+
     InspectionExtension.inspect(
       jpContext, Location.of("META-INF/asakusa-spark/plan.json", '/'), plan)
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/AggregateCompiler.scala
@@ -56,7 +56,7 @@ class AggregateCompiler extends NodeCompiler {
         operator,
         mapSideCombine =
           subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
-        subPlanInfo.getLabel,
+        subplan.label,
         subplan.getOutputs.toSeq) with CacheOnce
 
     context.addClass(builder)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/CoGroupCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/CoGroupCompiler.scala
@@ -49,7 +49,7 @@ class CoGroupCompiler extends NodeCompiler {
     val builder =
       new CoGroupClassBuilder(
         operator)(
-        subPlanInfo.getLabel,
+        subplan.label,
         subplan.getOutputs.toSeq) with CacheOnce
 
     context.addClass(builder)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectInputCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectInputCompiler.scala
@@ -71,7 +71,7 @@ class DirectInputCompiler extends NodeCompiler {
         inputFormatInfo.getKeyClass.asType,
         inputFormatInfo.getValueClass.asType,
         inputFormatInfo.getExtraConfiguration.toMap)(
-        subPlanInfo.getLabel,
+        subplan.label,
         subplan.getOutputs.toSeq) with CacheOnce
 
     context.addClass(builder)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectOutputPrepareCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectOutputPrepareCompiler.scala
@@ -69,12 +69,12 @@ class DirectOutputPrepareCompiler extends NodeCompiler {
         operator)(
         pattern,
         model)(
-        subPlanInfo.getLabel) with CacheOnce
+        subplan.label) with CacheOnce
     } else {
       new DirectOutputPrepareFlatClassBuilder(
         operator)(
         model)(
-        subPlanInfo.getLabel) with CacheOnce
+        subplan.label) with CacheOnce
     }
 
     context.addClass(builder)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/ExtractCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/ExtractCompiler.scala
@@ -50,7 +50,7 @@ class ExtractCompiler extends NodeCompiler {
     val builder =
       new ExtractClassBuilder(
         marker)(
-        subPlanInfo.getLabel,
+        subplan.label,
         subplan.getOutputs.toSeq) with CacheOnce
 
     context.addClass(builder)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/JobClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/JobClassBuilder.scala
@@ -309,9 +309,9 @@ class JobClassBuilder(
       Option(subplan.getAttribute(classOf[NameInfo]))
         .map(_.getName))
       .flatten match {
-      case Seq() => "N/A"
-      case s => s.mkString(":")
-    }
+        case Seq() => "N/A"
+        case s: Seq[String] => s.mkString(":")
+      }
     broadcast.dup().invokeInit(
       nodes(),
       option(

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/TemporaryInputCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/TemporaryInputCompiler.scala
@@ -66,7 +66,7 @@ class TemporaryInputCompiler extends NodeCompiler {
         operator,
         operator.getDataType.asType,
         inputRef.getPaths.toSeq.sorted)(
-        subPlanInfo.getLabel,
+        subplan.label,
         subplan.getOutputs.toSeq) with CacheOnce
 
     context.addClass(builder)

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/TemporaryOutputCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/TemporaryOutputCompiler.scala
@@ -69,7 +69,7 @@ class TemporaryOutputCompiler extends NodeCompiler {
     val builder =
       new TemporaryOutputClassBuilder(
         operator)(
-        subPlanInfo.getLabel)
+        subplan.label)
 
     context.addClass(builder)
   }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/package.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/package.scala
@@ -237,7 +237,7 @@ package object compiler {
           .flatMap(info => Option(info.getLabel)))
         .flatten match {
           case Seq() => "N/A"
-          case s => s.mkString(":")
+          case s: Seq[String] => s.mkString(":")
         }
     }
   }

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/package.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/package.scala
@@ -18,17 +18,15 @@ package com.asakusafw.spark
 import java.lang.{ Boolean => JBoolean }
 
 import scala.collection.JavaConversions._
-
 import org.objectweb.asm.Type
-
 import com.asakusafw.lang.compiler.analyzer.util.{ BranchOperatorUtil, MasterJoinOperatorUtil }
 import com.asakusafw.lang.compiler.api.CompilerOptions
 import com.asakusafw.lang.compiler.api.reference.DataModelReference
 import com.asakusafw.lang.compiler.model.PropertyName
 import com.asakusafw.lang.compiler.model.description._
 import com.asakusafw.lang.compiler.model.graph._
-import com.asakusafw.runtime.value._
-import com.asakusafw.spark.tools.asm._
+import com.asakusafw.lang.compiler.planning.SubPlan
+import com.asakusafw.spark.compiler.planning.{ NameInfo, SubPlanInfo }
 
 package object compiler {
 
@@ -220,6 +218,27 @@ package object compiler {
         (dataModelRef.findProperty(ordering.getPropertyName).getType.asType,
           ordering.getDirection == Group.Direction.ASCENDANT)
       }
+    }
+  }
+
+  implicit class SubPlanNames(val subplan: SubPlan) extends AnyVal {
+
+    def name: String = {
+      Option(subplan.getAttribute(classOf[NameInfo]))
+        .map(_.getName)
+        .getOrElse("N/A")
+    }
+
+    def label: String = {
+      Seq(
+        Option(subplan.getAttribute(classOf[NameInfo]))
+          .map(_.getName),
+        Option(subplan.getAttribute(classOf[SubPlanInfo]))
+          .flatMap(info => Option(info.getLabel)))
+        .flatten match {
+          case Seq() => "N/A"
+          case s => s.mkString(":")
+        }
     }
   }
 }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/AggregateCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/AggregateCompiler.scala
@@ -69,7 +69,7 @@ class AggregateCompiler extends RoundAwareNodeCompiler {
             operator,
             mapSideCombine =
               subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheAlways
         case IterativeInfo.RecomputeKind.PARAMETER =>
           new AggregateClassBuilder(
@@ -78,7 +78,7 @@ class AggregateCompiler extends RoundAwareNodeCompiler {
             operator,
             mapSideCombine =
               subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheByParameter {
 
             override val parameters: Set[String] = iterativeInfo.getParameters.toSet
@@ -90,7 +90,7 @@ class AggregateCompiler extends RoundAwareNodeCompiler {
             operator,
             mapSideCombine =
               subPlanInfo.getDriverOptions.contains(SubPlanInfo.DriverOption.PARTIAL))(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheOnce
       }
 

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/CoGroupCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/CoGroupCompiler.scala
@@ -60,12 +60,12 @@ class CoGroupCompiler extends RoundAwareNodeCompiler {
         case IterativeInfo.RecomputeKind.ALWAYS =>
           new CoGroupClassBuilder(
             operator)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheAlways
         case IterativeInfo.RecomputeKind.PARAMETER =>
           new CoGroupClassBuilder(
             operator)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheByParameter {
 
             override val parameters: Set[String] = iterativeInfo.getParameters.toSet
@@ -73,7 +73,7 @@ class CoGroupCompiler extends RoundAwareNodeCompiler {
         case IterativeInfo.RecomputeKind.NEVER =>
           new CoGroupClassBuilder(
             operator)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheOnce
       }
 

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectInputCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectInputCompiler.scala
@@ -78,7 +78,7 @@ class DirectInputCompiler extends RoundAwareNodeCompiler {
             inputFormatInfo.getKeyClass.asType,
             inputFormatInfo.getValueClass.asType,
             inputFormatInfo.getExtraConfiguration.toMap)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheAlways
         case IterativeInfo.RecomputeKind.PARAMETER =>
           new DirectInputClassBuilder(
@@ -87,7 +87,7 @@ class DirectInputCompiler extends RoundAwareNodeCompiler {
             inputFormatInfo.getKeyClass.asType,
             inputFormatInfo.getValueClass.asType,
             inputFormatInfo.getExtraConfiguration.toMap)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheByParameter {
 
             override val parameters: Set[String] = iterativeInfo.getParameters.toSet
@@ -99,7 +99,7 @@ class DirectInputCompiler extends RoundAwareNodeCompiler {
             inputFormatInfo.getKeyClass.asType,
             inputFormatInfo.getValueClass.asType,
             inputFormatInfo.getExtraConfiguration.toMap)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheOnce
       }
 

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareEachForIterativeCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareEachForIterativeCompiler.scala
@@ -77,13 +77,13 @@ class DirectOutputPrepareEachForIterativeCompiler extends RoundAwareNodeCompiler
             operator)(
             pattern,
             model)(
-            subPlanInfo.getLabel) with CacheAlways
+            subplan.label) with CacheAlways
         case IterativeInfo.RecomputeKind.PARAMETER =>
           new DirectOutputPrepareGroupEachForIterativeClassBuilder(
             operator)(
             pattern,
             model)(
-            subPlanInfo.getLabel) with CacheByParameter {
+            subplan.label) with CacheByParameter {
 
             override val parameters: Set[String] = iterativeInfo.getParameters.toSet
           }
@@ -92,7 +92,7 @@ class DirectOutputPrepareEachForIterativeCompiler extends RoundAwareNodeCompiler
             operator)(
             pattern,
             model)(
-            subPlanInfo.getLabel) with CacheOnce
+            subplan.label) with CacheOnce
       }
     } else {
       iterativeInfo.getRecomputeKind match {
@@ -100,12 +100,12 @@ class DirectOutputPrepareEachForIterativeCompiler extends RoundAwareNodeCompiler
           new DirectOutputPrepareEachFlatForIterativeClassBuilder(
             operator)(
             model)(
-            subPlanInfo.getLabel) with CacheAlways
+            subplan.label) with CacheAlways
         case IterativeInfo.RecomputeKind.PARAMETER =>
           new DirectOutputPrepareEachFlatForIterativeClassBuilder(
             operator)(
             model)(
-            subPlanInfo.getLabel) with CacheByParameter {
+            subplan.label) with CacheByParameter {
 
             override val parameters: Set[String] = iterativeInfo.getParameters.toSet
           }
@@ -113,7 +113,7 @@ class DirectOutputPrepareEachForIterativeCompiler extends RoundAwareNodeCompiler
           new DirectOutputPrepareEachFlatForIterativeClassBuilder(
             operator)(
             model)(
-            subPlanInfo.getLabel) with CacheOnce
+            subplan.label) with CacheOnce
       }
     }
 

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareForIterativeCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/DirectOutputPrepareForIterativeCompiler.scala
@@ -50,7 +50,7 @@ object DirectOutputPrepareForIterativeCompiler {
       operator)(
       pattern,
       model)(
-      subPlanInfo.getLabel) with CacheOnce
+      subplan.label) with CacheOnce
 
     context.addClass(builder)
   }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/ExtractCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/ExtractCompiler.scala
@@ -61,12 +61,12 @@ class ExtractCompiler extends RoundAwareNodeCompiler {
         case IterativeInfo.RecomputeKind.ALWAYS =>
           new ExtractClassBuilder(
             marker)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheAlways
         case IterativeInfo.RecomputeKind.PARAMETER =>
           new ExtractClassBuilder(
             marker)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheByParameter {
 
             override val parameters: Set[String] = iterativeInfo.getParameters.toSet
@@ -74,7 +74,7 @@ class ExtractCompiler extends RoundAwareNodeCompiler {
         case IterativeInfo.RecomputeKind.NEVER =>
           new ExtractClassBuilder(
             marker)(
-            subPlanInfo.getLabel,
+            subplan.label,
             subplan.getOutputs.toSeq) with CacheOnce
       }
 

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/IterativeJobClassBuilder.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/IterativeJobClassBuilder.scala
@@ -382,7 +382,7 @@ class IterativeJobClassBuilder(
         .map(_.getName))
       .flatten match {
       case Seq() => "N/A"
-      case s => s.mkString(":")
+      case s: Seq[String] => s.mkString(":")
     }
     broadcast.dup()
     val arguments = Seq.newBuilder[Stack]

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryInputCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryInputCompiler.scala
@@ -84,14 +84,14 @@ class TemporaryInputCompiler extends RoundAwareNodeCompiler {
               operator,
               operator.getDataType.asType,
               inputRef.getPaths.toSeq.sorted)(
-              subPlanInfo.getLabel,
+              subplan.label,
               subplan.getOutputs.toSeq) with CacheAlways
           case IterativeInfo.RecomputeKind.PARAMETER =>
             new TemporaryInputClassBuilder(
               operator,
               operator.getDataType.asType,
               inputRef.getPaths.toSeq.sorted)(
-              subPlanInfo.getLabel,
+              subplan.label,
               subplan.getOutputs.toSeq) with CacheByParameter {
 
               override val parameters: Set[String] = iterativeInfo.getParameters.toSet
@@ -101,7 +101,7 @@ class TemporaryInputCompiler extends RoundAwareNodeCompiler {
               operator,
               operator.getDataType.asType,
               inputRef.getPaths.toSeq.sorted)(
-              subPlanInfo.getLabel,
+              subplan.label,
               subplan.getOutputs.toSeq) with CacheOnce
         }
 

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryOutputCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryOutputCompiler.scala
@@ -77,7 +77,7 @@ class TemporaryOutputCompiler extends RoundAwareNodeCompiler {
     val builder =
       new TemporaryOutputClassBuilder(
         operator)(
-        subPlanInfo.getLabel)
+        subplan.label)
 
     context.addClass(builder)
   }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/package.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/package.scala
@@ -36,7 +36,7 @@ package object graph {
           .flatMap(info => Option(info.getLabel)))
         .flatten match {
         case Seq() => "N/A"
-        case s => s.mkString(":")
+        case s: Seq[String] => s.mkString(":")
       }
     }
   }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/package.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/package.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.spark.extensions.iterativebatch.compiler
+
+import com.asakusafw.lang.compiler.planning.SubPlan
+import com.asakusafw.spark.compiler.planning.{ NameInfo, SubPlanInfo }
+
+package object graph {
+
+  implicit class SubPlanNames(val subplan: SubPlan) extends AnyVal {
+
+    def name: String = {
+      Option(subplan.getAttribute(classOf[NameInfo]))
+        .map(_.getName)
+        .getOrElse("N/A")
+    }
+
+    def label: String = {
+      Seq(
+        Option(subplan.getAttribute(classOf[NameInfo]))
+          .map(_.getName),
+        Option(subplan.getAttribute(classOf[SubPlanInfo]))
+          .flatMap(info => Option(info.getLabel)))
+        .flatten match {
+        case Seq() => "N/A"
+        case s => s.mkString(":")
+      }
+    }
+  }
+}

--- a/planner/pom.xml
+++ b/planner/pom.xml
@@ -18,6 +18,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.asakusafw.lang.utils</groupId>
+      <artifactId>asakusa-lang-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.asakusafw.lang.compiler</groupId>
       <artifactId>asakusa-compiler-plan</artifactId>
     </dependency>
@@ -28,6 +32,10 @@
     <dependency>
       <groupId>com.asakusafw.iterative</groupId>
       <artifactId>asakusa-compiler-model-iterative</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw.lang.compiler</groupId>
+      <artifactId>asakusa-compiler-extension-operator</artifactId>
     </dependency>
     <dependency>
       <groupId>com.asakusafw</groupId>

--- a/planner/src/main/java/com/asakusafw/spark/compiler/planning/NameInfo.java
+++ b/planner/src/main/java/com/asakusafw/spark/compiler/planning/NameInfo.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.spark.compiler.planning;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.asakusafw.lang.compiler.common.AttributeContainer;
+import com.asakusafw.lang.compiler.common.AttributeProvider;
+
+/**
+ * Naming information for planning elements.
+ * @since 0.4.2
+ */
+public class NameInfo {
+
+    private final String name;
+
+    /**
+     * Creates a new instance.
+     * @param name the element name
+     */
+    public NameInfo(String name) {
+        Objects.requireNonNull(name);
+        this.name = name;
+    }
+
+    static void bind(AttributeContainer element, String name) {
+        element.putAttribute(NameInfo.class, new NameInfo(name));
+    }
+
+    /**
+     * Returns the name of the given element.
+     * @param element the target element
+     * @return the element name, or {@code empty} if it is not defined
+     */
+    public static String getName(AttributeProvider element) {
+        return Optional.ofNullable(element.getAttribute(NameInfo.class))
+                .map(NameInfo::getName)
+                .get();
+    }
+
+    /**
+     * Returns the element name.
+     * @return the element name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/planner/src/main/java/com/asakusafw/spark/compiler/planning/Util.java
+++ b/planner/src/main/java/com/asakusafw/spark/compiler/planning/Util.java
@@ -16,15 +16,44 @@
 package com.asakusafw.spark.compiler.planning;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
 
+import com.asakusafw.lang.compiler.model.graph.CoreOperator;
+import com.asakusafw.lang.compiler.model.graph.CustomOperator;
+import com.asakusafw.lang.compiler.model.graph.ExternalInput;
+import com.asakusafw.lang.compiler.model.graph.ExternalOutput;
+import com.asakusafw.lang.compiler.model.graph.ExternalPort;
+import com.asakusafw.lang.compiler.model.graph.FlowOperator;
+import com.asakusafw.lang.compiler.model.graph.MarkerOperator;
 import com.asakusafw.lang.compiler.model.graph.Operator;
 import com.asakusafw.lang.compiler.model.graph.Operator.OperatorKind;
+import com.asakusafw.lang.compiler.model.graph.OperatorArgument;
+import com.asakusafw.lang.compiler.model.graph.OperatorInput;
+import com.asakusafw.lang.compiler.model.graph.OperatorOutput;
+import com.asakusafw.lang.compiler.model.graph.OperatorPort;
+import com.asakusafw.lang.compiler.model.graph.Operators;
 import com.asakusafw.lang.compiler.model.graph.UserOperator;
+import com.asakusafw.lang.compiler.planning.Plan;
+import com.asakusafw.lang.compiler.planning.PlanMarker;
+import com.asakusafw.lang.compiler.planning.PlanMarkers;
+import com.asakusafw.lang.compiler.planning.Planning;
 import com.asakusafw.lang.compiler.planning.SubPlan;
+import com.asakusafw.lang.utils.common.Arguments;
+import com.asakusafw.lang.utils.common.Invariants;
+import com.asakusafw.lang.utils.common.Tuple;
+import com.asakusafw.utils.graph.Graph;
+import com.asakusafw.utils.graph.Graphs;
 
 final class Util {
 
@@ -38,6 +67,8 @@ final class Util {
         OperatorKind.INPUT,
         OperatorKind.OUTPUT,
     };
+
+    private static final long PRIME = 31L;
 
     private Util() {
         return;
@@ -100,5 +131,248 @@ final class Util {
         } else {
             return operator.toString();
         }
+    }
+
+    static boolean isPrimaryInput(SubPlan.Input port) {
+        PlanMarker marker = PlanMarkers.get(port.getOperator());
+        return marker != null && marker != PlanMarker.BROADCAST;
+    }
+
+    static boolean isEffectiveInput(SubPlan.Input port) {
+        PlanMarker marker = PlanMarkers.get(port.getOperator());
+        return marker == PlanMarker.CHECKPOINT || marker == PlanMarker.GATHER || marker == PlanMarker.BROADCAST;
+    }
+
+    static <T> Map<T, String> computeIds(String prefix, List<T> sorted) {
+        int digits = getNumberOfDigits(sorted.size());
+        Map<T, String> results = new HashMap<>();
+        for (T element : sorted) {
+            String id = prefix + toStringWithLeadingZeros(results.size(), digits);
+            results.put(element, id);
+        }
+        return results;
+    }
+
+    private static String toStringWithLeadingZeros(int value, int digits) {
+        Arguments.require(value >= 0);
+        StringBuilder buf = new StringBuilder(digits);
+        for (int i = getNumberOfDigits(value); i < digits; i++) {
+            buf.append('0');
+        }
+        buf.append(value);
+        return buf.toString();
+    }
+
+    private static int getNumberOfDigits(int value) {
+        Arguments.require(value >= 0);
+        if (value < 10) {
+            return 1;
+        }
+        int log = (int) Math.floor(Math.log10(value));
+        return log + 1;
+    }
+
+    static <T, P> Map<T, String> computeIds(
+            String prefix, Collection<? extends P> parents, Function<P, List<T>> sorter) {
+        Map<T, String> results = new HashMap<>();
+        for (P parent : parents) {
+            List<T> sorted = sorter.apply(parent);
+            Map<T, String> map = computeIds(prefix, sorted);
+            map.forEach((element, label) -> {
+                results.merge(element, label, (a, b) -> {
+                    throw new IllegalStateException();
+                });
+            });
+        }
+        return results;
+    }
+
+    static List<SubPlan> sortElements(Plan plan) {
+        List<SubPlan> results = new ArrayList<>();
+        Graph<SubPlan> graph = Planning.toDependencyGraph(plan);
+        while (graph.isEmpty() == false) {
+            Set<SubPlan> heads = Graphs.collectTails(graph);
+            List<SubPlan> sorted = sort(heads, Util::getDigest);
+            graph.removeNodes(sorted);
+            results.addAll(sorted);
+        }
+        return results;
+    }
+
+    static List<SubPlan.Input> sortInputs(SubPlan sub) {
+        List<SubPlan.Input> primary = new ArrayList<>();
+        List<SubPlan.Input> broadcast = new ArrayList<>();
+        List<SubPlan.Input> dummy = new ArrayList<>();
+        for (SubPlan.Input port : sub.getInputs()) {
+            if (isEffectiveInput(port)) {
+                if (isPrimaryInput(port)) {
+                    primary.add(port);
+                } else {
+                    broadcast.add(port);
+                }
+            } else {
+                dummy.add(port);
+            }
+        }
+        List<SubPlan.Input> results = new ArrayList<>();
+        results.addAll(sortPrimaryInputs(primary));
+        results.addAll(sort(broadcast, Util::getDigest));
+        results.addAll(sort(dummy, Util::getDigest));
+        return results;
+    }
+
+    private static List<SubPlan.Input> sortPrimaryInputs(List<SubPlan.Input> primary) {
+        if (primary.size() <= 1) {
+            return primary;
+        }
+        Map<Operator, SubPlan.Input> map = primary.stream()
+                .collect(Collectors.toMap(SubPlan.Input::getOperator, Function.identity()));
+        List<Operator> candidates = primary.stream()
+            .map(p -> p.getOperator())
+            .peek(o -> Invariants.require(PlanMarkers.get(o) == PlanMarker.GATHER))
+            .flatMap(o -> Operators.getSuccessors(o).stream())
+            .distinct()
+            .collect(Collectors.toList());
+        Invariants.require(candidates.size() == 1);
+        List<SubPlan.Input> results = candidates.get(0).getInputs().stream()
+            .map(OperatorInput::getOpposites)
+            .filter(x -> x.isEmpty() == false)
+            .peek(x -> Invariants.require(x.size() == 1))
+            .map(x -> x.iterator().next().getOwner())
+            .filter(map::containsKey)
+            .map(map::get)
+            .collect(Collectors.toList());
+        Invariants.require(results.size() == primary.size());
+        return results;
+    }
+
+    static List<SubPlan.Output> sortOutputs(SubPlan sub) {
+        return sort(sub.getOutputs(), Util::getDigest);
+    }
+
+    static <T> List<T> sort(Collection<? extends T> elements, ToLongFunction<? super T> digester) {
+        return elements.stream()
+                .map(e -> new Tuple<>(e, digester.applyAsLong(e)))
+                .sorted(Comparator.comparingLong(Tuple::right))
+                .map(Tuple::left)
+                .collect(Collectors.toList());
+    }
+
+    static long getDigest(SubPlan element) {
+        return getOperatorSetDigest(element.getOperators());
+    }
+
+    static long getDigest(SubPlan.Input element) {
+        long result = 0;
+        result = result * PRIME + getDigest(element.getOwner());
+        result = result * PRIME + getConnectedSetDigest(element.getOperator().getOutput().getOpposites());
+        return result;
+    }
+
+    static long getDigest(SubPlan.Output element) {
+        long result = 1;
+        result = result * PRIME + getDigest(element.getOwner());
+        result = result * PRIME + getConnectedSetDigest(element.getOperator().getInput().getOpposites());
+        return result;
+    }
+
+    private static long getConnectedSetDigest(Collection<? extends OperatorPort> opposites) {
+        long result = 0;
+        for (OperatorPort port : opposites) {
+            long local = 0;
+            local = local * PRIME + Objects.hashCode(port.getName());
+            local = local * PRIME + Objects.hashCode(port.getDataType());
+            local = local * PRIME + getDigest(port.getOwner());
+            result += local;
+        }
+        return result;
+    }
+
+    static long getDigest(Operator operator) {
+        switch (operator.getOperatorKind()) {
+        case INPUT:
+            return getOperatorDigest0((ExternalInput) operator);
+        case OUTPUT:
+            return getOperatorDigest0((ExternalOutput) operator);
+        case USER:
+            return getOperatorDigest0((UserOperator) operator);
+        case CORE:
+            return getOperatorDigest0((CoreOperator) operator);
+        case FLOW:
+            return getOperatorDigest0((FlowOperator) operator);
+        case MARKER:
+            return getOperatorDigest0((MarkerOperator) operator);
+        case CUSTOM:
+            return getOperatorDigest0((CustomOperator) operator);
+        default:
+            return operator.getOperatorKind().hashCode();
+        }
+    }
+
+    private static long getOperatorDigest0(ExternalPort operator) {
+        long result = getOperatorCommonDigest(operator);
+        result = result * PRIME + Objects.hashCode(operator.getName());
+        return result;
+    }
+
+    private static long getOperatorDigest0(UserOperator operator) {
+        long result = getOperatorCommonDigest(operator);
+        result = result * PRIME + Objects.hashCode(operator.getAnnotation());
+        result = result * PRIME + Objects.hashCode(operator.getMethod());
+        result = result * PRIME + Objects.hashCode(operator.getImplementationClass());
+        return result;
+    }
+
+    private static long getOperatorDigest0(CoreOperator operator) {
+        long result = getOperatorCommonDigest(operator);
+        result = result * PRIME + Objects.hashCode(operator.getCoreOperatorKind());
+        return result;
+    }
+
+    private static long getOperatorDigest0(FlowOperator operator) {
+        long result = getOperatorCommonDigest(operator);
+        result = result * PRIME + Objects.hashCode(operator.getDescriptionClass());
+        result = result * PRIME + getOperatorSetDigest(operator.getOperatorGraph().getOperators());
+        return result;
+    }
+
+    private static long getOperatorDigest0(MarkerOperator operator) {
+        long result = getOperatorCommonDigest(operator);
+        return result;
+    }
+
+    private static long getOperatorDigest0(CustomOperator operator) {
+        long result = getOperatorCommonDigest(operator);
+        result = result * PRIME + Objects.hashCode(operator.getCategory());
+        return result;
+    }
+
+    private static long getOperatorCommonDigest(Operator operator) {
+        long result = operator.getOperatorKind().hashCode();
+        for (OperatorInput property : operator.getInputs()) {
+            result = result * PRIME + Objects.hashCode(property.getPropertyKind());
+            result = result * PRIME + Objects.hashCode(property.getName());
+            result = result * PRIME + Objects.hashCode(property.getDataType());
+            result = result * PRIME + Objects.hashCode(property.getGroup());
+        }
+        for (OperatorOutput property : operator.getOutputs()) {
+            result = result * PRIME + Objects.hashCode(property.getPropertyKind());
+            result = result * PRIME + Objects.hashCode(property.getName());
+            result = result * PRIME + Objects.hashCode(property.getDataType());
+        }
+        for (OperatorArgument property : operator.getArguments()) {
+            result = result * PRIME + Objects.hashCode(property.getPropertyKind());
+            result = result * PRIME + Objects.hashCode(property.getName());
+            result = result * PRIME + Objects.hashCode(property.getValue());
+        }
+        return result;
+    }
+
+    private static long getOperatorSetDigest(Collection<? extends Operator> operators) {
+        long result = 0L;
+        for (Operator operator : operators) {
+            result += getDigest(operator);
+        }
+        return result;
     }
 }

--- a/planner/src/test/java/com/asakusafw/spark/compiler/planning/PlanningTestRoot.java
+++ b/planner/src/test/java/com/asakusafw/spark/compiler/planning/PlanningTestRoot.java
@@ -242,6 +242,7 @@ public abstract class PlanningTestRoot {
                 managed.add(operator);
             }
         }
+        assertThat(SparkPlanning.toInfo(detail.getPlan()), is(notNullValue()));
         return new MockOperators(managed);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,11 @@ encoding/<project>=UTF-8
       </dependency>
 
       <dependency>
+        <groupId>com.asakusafw.lang.utils</groupId>
+        <artifactId>asakusa-lang-common</artifactId>
+        <version>${asakusafw-lang.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.asakusafw.lang.compiler</groupId>
         <artifactId>asakusa-compiler-common</artifactId>
         <version>${asakusafw-lang.version}</version>
@@ -547,6 +552,11 @@ encoding/<project>=UTF-8
       <dependency>
         <groupId>com.asakusafw.lang.compiler</groupId>
         <artifactId>asakusa-compiler-extension-directio</artifactId>
+        <version>${asakusafw-lang.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.asakusafw.lang.compiler</groupId>
+        <artifactId>asakusa-compiler-extension-operator</artifactId>
         <version>${asakusafw-lang.version}</version>
       </dependency>
       <dependency>

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Aggregate.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Aggregate.scala
@@ -72,7 +72,7 @@ abstract class Aggregate[V: ClassTag, C: ClassTag](
                       combiner.insertAll(
                         new ResourceBrokingIterator(
                           rc.hadoopConf.value,
-                          iter))
+                          iter)(label))
                       val context = TaskContext.get
                       new InterruptibleIterator(context, combiner.iterator)
                     }, preservesPartitioning = true)
@@ -83,7 +83,7 @@ abstract class Aggregate[V: ClassTag, C: ClassTag](
                   combiner.insertAll(
                     new ResourceBrokingIterator(
                       rc.hadoopConf.value,
-                      iter.map { case (k, v) => (k.dropOrdering, v) }))
+                      iter.map { case (k, v) => (k.dropOrdering, v) })(label))
                   val context = TaskContext.get
                   new InterruptibleIterator(context, combiner.iterator)
                 }, preservesPartitioning = true)
@@ -94,7 +94,7 @@ abstract class Aggregate[V: ClassTag, C: ClassTag](
                   combiner.insertAll(
                     new ResourceBrokingIterator(
                       rc.hadoopConf.value,
-                      iter.map { case (k, v) => (k.dropOrdering, v) }))
+                      iter.map { case (k, v) => (k.dropOrdering, v) })(label))
                   val context = TaskContext.get
                   new InterruptibleIterator(context, combiner.iterator)
                 }, preservesPartitioning = true)

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Branching.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Branching.scala
@@ -36,6 +36,8 @@ trait Branching[T] {
 
   def jobContext: JobContext
 
+  def label: String
+
   def branchKeys: Set[BranchKey]
 
   def partitioners: Map[BranchKey, Option[Partitioner]]
@@ -65,7 +67,7 @@ trait Branching[T] {
             hadoopConf.value,
             iterateFragments(iter, broadcasts)(fragmentBufferSize).map {
               case (Branch(_, k), v) => (k, v)
-            })
+            })(label)
         }, preservesPartitioning = true)
         () => mapped
       })
@@ -82,7 +84,7 @@ trait Branching[T] {
               } else {
                 iterateWithoutCombiner(fragmentsIter)
               }
-            })
+            })(label)
         },
         partitioners =
           partitioners.map {

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Node.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/Node.scala
@@ -19,6 +19,8 @@ package graph
 import org.apache.spark.backdoor._
 import org.apache.spark.util.backdoor._
 
+import scala.util.control.NonFatal
+
 trait Node extends Serializable {
 
   implicit def jobContext: JobContext
@@ -30,6 +32,9 @@ trait Node extends Serializable {
       CallSite(rc.roundId.map(r => s"${label}: [${r}]").getOrElse(label), rc.toString))
     try {
       block
+    } catch {
+      case e: VertexException => throw e
+      case NonFatal(e) => throw new VertexException(label, e)
     } finally {
       jobContext.sparkContext.clearCallSite()
     }

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/VertexException.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/VertexException.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.spark.runtime.graph
+
+import org.apache.spark.SparkException
+
+class VertexException(label: String, cause: Throwable = null) extends SparkException(
+  s"error occurred while processing vertex: ${label}",
+  cause)

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/VertexException.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/VertexException.scala
@@ -17,6 +17,7 @@ package com.asakusafw.spark.runtime.graph
 
 import org.apache.spark.SparkException
 
-class VertexException(label: String, cause: Throwable = null) extends SparkException(
+class VertexException(label: String, cause: Throwable = null) // scalastyle:ignore
+  extends SparkException(
   s"error occurred while processing vertex: ${label}",
   cause)


### PR DESCRIPTION
## Summary

This PR enables to provide information about processing location in Spark.

## Background, Problem or Goal of the patch

In the latest implementation, Asakusa on Spark does not provide location information to understand where error was occurred easily. This PR provides uniques IDs into each stage and display them in error logs.

## Design of the fix, or a new feature

This also provides (reduced) execution plan information into `batch-info.json`, and then developers can obtain it by using the viewer tool introduced in asakusafw/asakusafw-compiler#134. It also includes the above IDs of each stage as "vertex name".

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#134
* asakusafw/asakusafw-compiler#135
