### PR TITLE
Gradle plugins should refer `asakusa-lang-gradle`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ This project includes the followings:
 And then import projects from Eclipse
 
 ## How to build Gradle Plugin
+
 ```sh
 cd gradle
-./gradlew clean build
+./gradlew clean build [install] [-PmavenLocal]
 ```
 
 ## Referred Projects

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -54,7 +54,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: parentPom.sdkVersion
+    compile group: 'com.asakusafw.lang', name: 'asakusa-lang-gradle', version: parentPom.langVersion
     testCompile gradleTestKit()
     testCompile group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: parentPom.sdkVersion, classifier: 'tests'
     testCompile 'junit:junit:4.11'
@@ -79,8 +79,8 @@ if (project.hasProperty('referProject')) {
         classpath.entries = classpath.entries.collect { entry ->
             if (entry instanceof org.gradle.plugins.ide.eclipse.model.Library \
                     && entry.moduleVersion \
-                    && entry.moduleVersion.name == 'asakusa-gradle-plugins') {
-                new org.gradle.plugins.ide.eclipse.model.ProjectDependency('/asakusa-gradle-plugins')
+                    && entry.moduleVersion.name in ['asakusa-gradle-plugins', 'asakusa-lang-gradle']) {
+                new org.gradle.plugins.ide.eclipse.model.ProjectDependency("/${entry.moduleVersion.name}")
             } else {
                 entry
             }

--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkOrganizerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkOrganizerPlugin.groovy
@@ -24,6 +24,7 @@ import com.asakusafw.gradle.plugins.AsakusafwOrganizerPlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
 import com.asakusafw.gradle.plugins.internal.PluginUtils
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangOrganizerPlugin
 import com.asakusafw.spark.gradle.plugins.AsakusafwOrganizerSparkExtension
 
 /**
@@ -40,7 +41,7 @@ class AsakusaSparkOrganizerPlugin implements Plugin<Project> {
         this.project = project
         this.organizers = project.container(AsakusaSparkOrganizer)
 
-        project.apply plugin: 'asakusafw-organizer'
+        project.apply plugin: AsakusaLangOrganizerPlugin
         project.apply plugin: AsakusaSparkBasePlugin
 
         configureConvention()

--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkBasePlugin.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ResolutionStrategy
 import com.asakusafw.gradle.plugins.AsakusafwSdkExtension
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 import com.asakusafw.gradle.plugins.internal.PluginUtils
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangSdkPlugin
 
 /**
  * A base plug-in of {@link AsakusaSparkSdkPlugin}.
@@ -39,7 +40,7 @@ class AsakusaSparkSdkBasePlugin implements Plugin<Project> {
     void apply(Project project) {
         this.project = project
 
-        project.apply plugin: AsakusaSdkPlugin
+        project.apply plugin: AsakusaLangSdkPlugin
         project.apply plugin: AsakusaSparkBasePlugin
 
         configureTestkit()
@@ -55,15 +56,17 @@ class AsakusaSparkSdkBasePlugin implements Plugin<Project> {
         project.configurations {
             asakusaSparkCommon {
                 description 'Common libraries of Asakusa DSL Compiler for Spark'
+                extendsFrom project.configurations.asakusaLangCommon
                 exclude group: 'asm', module: 'asm'
             }
             asakusaSparkCompiler {
                 description 'Full classpath of Asakusa DSL Compiler for Spark'
-                extendsFrom project.configurations.compile
+                extendsFrom project.configurations.asakusaLangCompiler
                 extendsFrom project.configurations.asakusaSparkCommon
             }
             asakusaSparkTestkit {
                 description 'Asakusa DSL testkit classpath for Spark'
+                extendsFrom project.configurations.asakusaLangTestkit
                 extendsFrom project.configurations.asakusaSparkCommon
             }
         }
@@ -99,36 +102,8 @@ class AsakusaSparkSdkBasePlugin implements Plugin<Project> {
                     asakusaSparkCommon("com.asakusafw.spark:asakusa-spark-compiler:${base.featureVersion}") {
                         exclude module: 'hadoop-client'
                     }
-
-                    asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-cli:${base.langVersion}"
-                    asakusaSparkCommon "com.asakusafw:simple-graph:${base.coreVersion}"
-                    asakusaSparkCommon "com.asakusafw:java-dom:${base.coreVersion}"
-
-                    asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-cleanup:${base.langVersion}"
-                    asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.langVersion}"
-                    asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.langVersion}"
-
-                    asakusaSparkCompiler "com.asakusafw:asakusa-dsl-vocabulary:${base.coreVersion}"
-                    asakusaSparkCompiler "com.asakusafw:asakusa-runtime:${base.coreVersion}"
-                    asakusaSparkCompiler "com.asakusafw:asakusa-yaess-core:${base.coreVersion}"
-
                     asakusaSparkCommon "com.asakusafw.iterative:asakusa-compiler-extension-iterative:${base.langVersion}"
                     asakusaSparkCommon "com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-compiler-iterative:${base.featureVersion}"
-
-                    if (features.directio) {
-                        asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-directio:${base.langVersion}"
-                        asakusaSparkCompiler "com.asakusafw:asakusa-directio-vocabulary:${base.coreVersion}"
-                    }
-                    if (features.windgate) {
-                        asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-windgate:${base.langVersion}"
-                        asakusaSparkCompiler "com.asakusafw:asakusa-windgate-vocabulary:${base.coreVersion}"
-                    }
-                    if (features.hive) {
-                        asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.langVersion}"
-                    }
-                    if (features.incubating) {
-                        asakusaSparkCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-info:${base.langVersion}"
-                    }
                 }
                 if (features.testing) {
                     asakusaSparkTestkit "com.asakusafw.spark:asakusa-spark-test-adapter:${base.featureVersion}"

--- a/gradle/src/test/groovy/com/asakusafw/spark/gradle/plugins/AsakusaUpgradeTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/spark/gradle/plugins/AsakusaUpgradeTest.groovy
@@ -23,6 +23,7 @@ import org.junit.rules.TestName
 
 import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
 import com.asakusafw.gradle.plugins.GradleTestkitHelper
+import com.asakusafw.lang.gradle.plugins.AsakusafwLangPlugin
 
 /**
  * Tests for cross Gradle versions compatibility.
@@ -121,6 +122,8 @@ class AsakusaUpgradeTest {
         Set<File> classpath = GradleTestkitHelper.toClasspath(
             AsakusafwBasePlugin,
             'META-INF/gradle-plugins/asakusafw-sdk.properties',
+            AsakusafwLangPlugin,
+            'META-INF/gradle-plugins/asakusafw-lang.properties',
             AsakusafwSparkPlugin,
             'META-INF/gradle-plugins/asakusafw-spark.properties')
         String script = GradleTestkitHelper.getSimpleBuildScript(classpath, 'asakusafw-sdk', 'asakusafw-organizer', 'asakusafw-spark')

--- a/gradle/src/test/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkOrganizerPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkOrganizerPluginTest.groovy
@@ -24,6 +24,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangOrganizerPlugin
 import com.asakusafw.spark.gradle.plugins.AsakusafwOrganizerSparkExtension
 
 /**
@@ -52,6 +53,7 @@ class AsakusaSparkOrganizerPluginTest {
     void base() {
         assert project.plugins.hasPlugin('asakusafw-organizer') != null
         assert project.plugins.hasPlugin(AsakusaSparkBasePlugin) != null
+        assert project.plugins.hasPlugin(AsakusaLangOrganizerPlugin) != null
     }
 
     /**

--- a/gradle/src/test/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkPluginTest.groovy
@@ -32,6 +32,7 @@ import com.asakusafw.gradle.plugins.AsakusafwCompilerExtension
 import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
 import com.asakusafw.gradle.tasks.AsakusaCompileTask
 import com.asakusafw.gradle.tasks.internal.ResolutionUtils
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangSdkPlugin
 
 /**
  * Test for {@link AsakusaSparkSdkPlugin}.
@@ -59,6 +60,7 @@ class AsakusaSparkSdkPluginTest {
     void base() {
         assert project.plugins.hasPlugin('asakusafw-sdk') != null
         assert project.plugins.hasPlugin(AsakusaSparkBasePlugin) != null
+        assert project.plugins.hasPlugin(AsakusaLangSdkPlugin) != null
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR makes `asakusafw-spark` Gradle plug-in refer a new parent plug-in `asakusafw-lang` introduced asakusafw/asakusafw-compiler#142.

## Background, Problem or Goal of the patch

asakusafw/asakusafw-compiler#142 has introduced common Asakusa DSL compiler settings for this platform. It enables that introduce `tools/bin/info.sh` to deployment archives with using `asakusafw-spark`. This will also reduce impact on upstream structure changes.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#142
