### PR TITLE
Exclude hadoop-client from testkit dependencies.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/spark/gradle/plugins/internal/AsakusaSparkSdkBasePlugin.groovy
@@ -102,15 +102,25 @@ class AsakusaSparkSdkBasePlugin implements Plugin<Project> {
                     asakusaSparkCommon("com.asakusafw.spark:asakusa-spark-compiler:${base.featureVersion}") {
                         exclude module: 'hadoop-client'
                     }
-                    asakusaSparkCommon "com.asakusafw.iterative:asakusa-compiler-extension-iterative:${base.langVersion}"
-                    asakusaSparkCommon "com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-compiler-iterative:${base.featureVersion}"
+                    asakusaSparkCommon("com.asakusafw.iterative:asakusa-compiler-extension-iterative:${base.langVersion}")
+                    asakusaSparkCommon("com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-compiler-iterative:${base.featureVersion}") {
+                        exclude module: 'hadoop-client'
+                    }
                 }
                 if (features.testing) {
-                    asakusaSparkTestkit "com.asakusafw.spark:asakusa-spark-test-adapter:${base.featureVersion}"
-                    asakusaSparkTestkit "com.asakusafw.bridge:asakusa-bridge-runtime-all:${base.langVersion}"
-                    asakusaSparkTestkit "com.asakusafw.spark:asakusa-spark-runtime:${base.featureVersion}"
-                    asakusaSparkTestkit "com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-runtime-core:${base.featureVersion}"
-                    asakusaSparkTestkit "com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-runtime-iterative:${base.featureVersion}"
+                    asakusaSparkTestkit("com.asakusafw.spark:asakusa-spark-test-adapter:${base.featureVersion}") {
+                        exclude module: 'hadoop-client'
+                    }
+                    asakusaSparkTestkit("com.asakusafw.bridge:asakusa-bridge-runtime-all:${base.langVersion}")
+                    asakusaSparkTestkit("com.asakusafw.spark:asakusa-spark-runtime:${base.featureVersion}") {
+                        exclude module: 'hadoop-client'
+                    }
+                    asakusaSparkTestkit("com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-runtime-core:${base.featureVersion}") {
+                        exclude module: 'hadoop-client'
+                    }
+                    asakusaSparkTestkit("com.asakusafw.spark.extensions:asakusa-spark-extensions-iterativebatch-runtime-iterative:${base.featureVersion}") {
+                        exclude module: 'hadoop-client'
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR fixes classpath of Asakusa on Spark testkit which includes inconsistent version of hadoop libraries.

## Background, Problem or Goal of the patch

Since asakusafw/asakusafw#742, we reduced dependencies of Hadoop libraries `{hadoo-client=>hadoop-common+hadoop-mapreduce-client-jobclient}`, and Asakusa on Spark testkit requires redundant `hadoop-client` dependency. They makes test runtime classpath inconsistent (e.g. `hadoop-hdfs`).

## Design of the fix, or a new feature

This PR removes transitive dependency of `hadoop-client` from each Spark testkit libraries.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#742
