### PR TITLE
Bump Spark version to 2.2.0.

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectInputCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectInputCompiler.scala
@@ -18,12 +18,10 @@ package graph
 
 import scala.collection.JavaConversions._
 
-import org.apache.hadoop.io.NullWritable
 import org.objectweb.asm.Type
 
 import com.asakusafw.lang.compiler.model.graph.ExternalInput
 import com.asakusafw.lang.compiler.planning.SubPlan
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.spark.compiler.planning.SubPlanInfo
 import com.asakusafw.spark.compiler.spi.NodeCompiler
 

--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/TemporaryOutputCompiler.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/TemporaryOutputCompiler.scala
@@ -16,14 +16,13 @@
 package com.asakusafw.spark.compiler
 package graph
 
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileOutputFormat
+
 import scala.collection.JavaConversions._
-
 import org.objectweb.asm.Type
-
 import com.asakusafw.lang.compiler.extension.directio.DirectFileIoModels
 import com.asakusafw.lang.compiler.model.graph.ExternalOutput
 import com.asakusafw.lang.compiler.planning.SubPlan
-import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.spark.compiler.planning.SubPlanInfo
 import com.asakusafw.spark.compiler.spi.NodeCompiler
 
@@ -64,7 +63,7 @@ class TemporaryOutputCompiler extends NodeCompiler {
     context.addExternalOutput(
       operator.getName, operator.getInfo,
       Seq(context.options.getRuntimeWorkingPath(
-        s"${operator.getName}/*/${TemporaryOutputFormat.DEFAULT_FILE_NAME}-*")))
+        s"${operator.getName}/*/${TemporaryFileOutputFormat.DEFAULT_FILE_NAME}-*")))
 
     val builder =
       new TemporaryOutputClassBuilder(

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/InputClassBuilderSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/InputClassBuilderSpec.scala
@@ -19,22 +19,19 @@ package graph
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-
 import java.io.{ DataInput, DataOutput, File }
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
 import org.apache.hadoop.mapreduce.{ InputFormat, Job => MRJob }
-import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.hadoop.mapreduce.lib.output.{ FileOutputFormat, SequenceFileOutputFormat }
-
 import com.asakusafw.bridge.hadoop.directio.DirectFileInputFormat
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileOutputFormat
 import com.asakusafw.lang.compiler.api.CompilerOptions
 import com.asakusafw.lang.compiler.api.testing.MockJobflowProcessorContext
 import com.asakusafw.lang.compiler.hadoop.{ InputFormatInfo, InputFormatInfoExtension }
@@ -44,19 +41,12 @@ import com.asakusafw.lang.compiler.model.info.ExternalInputInfo
 import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
 import com.asakusafw.runtime.directio.hadoop.{ HadoopDataSource, SequenceFileFormat }
 import com.asakusafw.runtime.model.DataModel
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
-import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.compiler.planning.{ SubPlanInfo, SubPlanOutputInfo }
 import com.asakusafw.spark.compiler.spi.NodeCompiler
 import com.asakusafw.spark.runtime._
 import com.asakusafw.spark.runtime.JobContext.InputCounter
-import com.asakusafw.spark.runtime.graph.{
-  Broadcast,
-  BroadcastId,
-  DirectInput,
-  TemporaryInput
-}
+import com.asakusafw.spark.runtime.graph.{ Broadcast, BroadcastId, DirectInput, TemporaryInput }
 import com.asakusafw.spark.runtime.rdd.BranchKey
 
 abstract class InputClassBuilderSpec extends FlatSpec with ClassServerForAll with SparkForAll {
@@ -92,8 +82,8 @@ class TemporaryInputClassBuilderSpec
   behavior of classOf[TemporaryInputClassBuilder].getSimpleName
 
   val configurePath: (MRJob, String) => Unit = { (job, path) =>
-    job.setOutputFormatClass(classOf[TemporaryOutputFormat[Foo]])
-    TemporaryOutputFormat.setOutputPath(job, new Path(path))
+    job.setOutputFormatClass(classOf[TemporaryFileOutputFormat[Foo]])
+    FileOutputFormat.setOutputPath(job, new Path(path))
   }
 
   it should "build TemporaryInput class" in {

--- a/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/OutputClassBuilderSpec.scala
+++ b/compiler/src/test/scala/com/asakusafw/spark/compiler/graph/OutputClassBuilderSpec.scala
@@ -19,19 +19,18 @@ package graph
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-
 import java.io.{ DataInput, DataOutput, File }
+
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileInputFormat
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
 import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
-
 import com.asakusafw.bridge.stage.StageInfo
 import com.asakusafw.lang.compiler.api.CompilerOptions
 import com.asakusafw.lang.compiler.api.testing.MockJobflowProcessorContext
@@ -39,19 +38,12 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ ExternalOutput, MarkerOperator }
 import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
 import com.asakusafw.runtime.model.DataModel
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.compiler.planning.SubPlanInfo
 import com.asakusafw.spark.compiler.spi.NodeCompiler
 import com.asakusafw.spark.runtime._
 import com.asakusafw.spark.runtime.JobContext.OutputCounter.External
-import com.asakusafw.spark.runtime.graph.{
-  Broadcast,
-  BroadcastId,
-  ParallelCollectionSource,
-  Source,
-  TemporaryOutput
-}
+import com.asakusafw.spark.runtime.graph.{ Broadcast, BroadcastId, ParallelCollectionSource, Source, TemporaryOutput }
 import com.asakusafw.spark.runtime.rdd.BranchKey
 
 abstract class OutputClassBuilderSpec extends FlatSpec with ClassServerForAll with SparkForAll {
@@ -66,7 +58,7 @@ abstract class OutputClassBuilderSpec extends FlatSpec with ClassServerForAll wi
 
     sc.newAPIHadoopRDD(
       job.getConfiguration,
-      classOf[TemporaryInputFormat[Foo]],
+      classOf[TemporaryFileInputFormat[Foo]],
       classOf[NullWritable],
       classOf[Foo]).map(_._2.id.get).collect.toSeq.sorted
   }

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryOutputCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryOutputCompiler.scala
@@ -26,7 +26,11 @@ import com.asakusafw.lang.compiler.planning.SubPlan
 import com.asakusafw.spark.compiler.`package`._
 import com.asakusafw.spark.compiler.planning.SubPlanInfo
 import com.asakusafw.spark.compiler.spi.NodeCompiler
-import com.asakusafw.spark.compiler.graph.{ Instantiator, TemporaryOutputClassBuilder, TemporaryOutputInstantiator }
+import com.asakusafw.spark.compiler.graph.{
+  Instantiator,
+  TemporaryOutputClassBuilder,
+  TemporaryOutputInstantiator
+}
 import com.asakusafw.spark.extensions.iterativebatch.compiler.spi.RoundAwareNodeCompiler
 
 class TemporaryOutputCompiler extends RoundAwareNodeCompiler {

--- a/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryOutputCompiler.scala
+++ b/extensions/iterativebatch/compiler/core/src/main/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/TemporaryOutputCompiler.scala
@@ -16,23 +16,17 @@
 package com.asakusafw.spark.extensions.iterativebatch.compiler
 package graph
 
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileOutputFormat
+
 import scala.collection.JavaConversions._
-
 import org.objectweb.asm.Type
-
 import com.asakusafw.lang.compiler.extension.directio.DirectFileIoModels
 import com.asakusafw.lang.compiler.model.graph.ExternalOutput
 import com.asakusafw.lang.compiler.planning.SubPlan
-import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.spark.compiler.`package`._
 import com.asakusafw.spark.compiler.planning.SubPlanInfo
 import com.asakusafw.spark.compiler.spi.NodeCompiler
-import com.asakusafw.spark.compiler.graph.{
-  Instantiator,
-  TemporaryOutputClassBuilder,
-  TemporaryOutputInstantiator
-}
-
+import com.asakusafw.spark.compiler.graph.{ Instantiator, TemporaryOutputClassBuilder, TemporaryOutputInstantiator }
 import com.asakusafw.spark.extensions.iterativebatch.compiler.spi.RoundAwareNodeCompiler
 
 class TemporaryOutputCompiler extends RoundAwareNodeCompiler {
@@ -72,7 +66,7 @@ class TemporaryOutputCompiler extends RoundAwareNodeCompiler {
     context.addExternalOutput(
       operator.getName, operator.getInfo,
       Seq(context.options.getRuntimeWorkingPath(
-        s"${operator.getName}/*/${TemporaryOutputFormat.DEFAULT_FILE_NAME}-*")))
+        s"${operator.getName}/*/${TemporaryFileOutputFormat.DEFAULT_FILE_NAME}-*")))
 
     val builder =
       new TemporaryOutputClassBuilder(

--- a/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/InputClassBuilderSpec.scala
+++ b/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/InputClassBuilderSpec.scala
@@ -19,22 +19,20 @@ package graph
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-
 import java.io.{ DataInput, DataOutput, File }
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
 import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.hadoop.mapreduce.lib.output.{ FileOutputFormat, SequenceFileOutputFormat }
-
 import com.asakusafw.bridge.hadoop.directio.DirectFileInputFormat
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileOutputFormat
 import com.asakusafw.lang.compiler.api.CompilerOptions
 import com.asakusafw.lang.compiler.api.testing.MockJobflowProcessorContext
 import com.asakusafw.lang.compiler.common.DiagnosticException
@@ -47,24 +45,15 @@ import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
 import com.asakusafw.runtime.directio.hadoop.{ HadoopDataSource, SequenceFileFormat }
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.StageConstants
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
-import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.compiler.{ ClassServerForAll, FlowIdForEach }
 import com.asakusafw.spark.compiler.graph._
 import com.asakusafw.spark.compiler.planning.{ IterativeInfo, SubPlanInfo, SubPlanOutputInfo }
 import com.asakusafw.spark.runtime._
 import com.asakusafw.spark.runtime.JobContext.InputCounter
-import com.asakusafw.spark.runtime.graph.{
-  Broadcast,
-  BroadcastId,
-  DirectInput,
-  TemporaryInput
-}
+import com.asakusafw.spark.runtime.graph.{ Broadcast, BroadcastId, DirectInput, TemporaryInput }
 import com.asakusafw.spark.runtime.rdd.BranchKey
-
 import com.asakusafw.spark.extensions.iterativebatch.compiler.spi.RoundAwareNodeCompiler
-import com.asakusafw.spark.extensions.iterativebatch.runtime.graph.RoundAwareParallelCollectionSource
 
 abstract class InputClassBuilderSpec extends FlatSpec with ClassServerForAll with SparkForAll {
 
@@ -100,8 +89,8 @@ class TemporaryInputClassBuilderSpec
   behavior of classOf[TemporaryInputClassBuilder].getSimpleName
 
   val configurePath: (MRJob, String, Int) => Unit = { (job, parent, round) =>
-    job.setOutputFormatClass(classOf[TemporaryOutputFormat[Foo]])
-    TemporaryOutputFormat.setOutputPath(job, new Path(parent, s"foos_round_${round}"))
+    job.setOutputFormatClass(classOf[TemporaryFileOutputFormat[Foo]])
+    FileOutputFormat.setOutputPath(job, new Path(parent, s"foos_round_${round}"))
   }
 
   for {

--- a/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/IterativeJobCompilerSpec.scala
+++ b/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/IterativeJobCompilerSpec.scala
@@ -19,14 +19,12 @@ package graph
 import org.junit.runner.RunWith
 import org.scalatest.{ FlatSpec, Suites }
 import org.scalatest.junit.JUnitRunner
-
-import java.io.{ File, DataInput, DataOutput }
+import java.io.{ DataInput, DataOutput, File }
 import java.util.{ List => JList }
 
 import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect.{ classTag, ClassTag }
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
 import org.apache.hadoop.mapreduce.{ Job => MRJob }
@@ -35,17 +33,14 @@ import org.apache.hadoop.mapreduce.lib.output.{ FileOutputFormat, SequenceFileOu
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.objectweb.asm.Type
-
 import com.asakusafw.bridge.api.BatchContext
 import com.asakusafw.bridge.hadoop.directio.DirectFileInputFormat
+import com.asakusafw.bridge.hadoop.temporary.{ TemporaryFileInputFormat, TemporaryFileOutputFormat }
 import com.asakusafw.bridge.stage.StageInfo
 import com.asakusafw.lang.compiler.api.CompilerOptions
 import com.asakusafw.lang.compiler.api.testing.MockJobflowProcessorContext
 import com.asakusafw.lang.compiler.common.Location
-import com.asakusafw.lang.compiler.extension.directio.{
-  DirectFileIoConstants,
-  DirectFileOutputModel
-}
+import com.asakusafw.lang.compiler.extension.directio.{ DirectFileIoConstants, DirectFileOutputModel }
 import com.asakusafw.lang.compiler.hadoop.{ InputFormatInfo, InputFormatInfoExtension }
 import com.asakusafw.lang.compiler.inspection.{ AbstractInspectionExtension, InspectionExtension }
 import com.asakusafw.lang.compiler.model.description.{ ClassDescription, Descriptions }
@@ -57,8 +52,6 @@ import com.asakusafw.lang.compiler.planning._
 import com.asakusafw.runtime.core.Result
 import com.asakusafw.runtime.directio.hadoop.{ HadoopDataSource, SequenceFileFormat }
 import com.asakusafw.runtime.model.DataModel
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
-import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.runtime.value._
 import com.asakusafw.spark.compiler.{ ClassServerForAll, FlowIdForEach }
 import com.asakusafw.spark.compiler.directio.DirectOutputDescription
@@ -66,9 +59,8 @@ import com.asakusafw.spark.compiler.planning.SparkPlanning
 import com.asakusafw.spark.runtime._
 import com.asakusafw.spark.tools.asm._
 import com.asakusafw.vocabulary.flow.processor.PartialAggregation
-import com.asakusafw.vocabulary.model.{ Key, Joined, Summarized }
+import com.asakusafw.vocabulary.model.{ Joined, Key, Summarized }
 import com.asakusafw.vocabulary.operator._
-
 import com.asakusafw.spark.extensions.iterativebatch.runtime.IterativeBatchExecutor
 import com.asakusafw.spark.extensions.iterativebatch.runtime.graph.IterativeJob
 
@@ -120,8 +112,8 @@ class IterativeJobCompilerSpecBase(threshold: Option[Int], parallelism: Option[I
   }
 
   val configurePath: (MRJob, File, String) => Unit = { (job, path, name) =>
-    job.setOutputFormatClass(classOf[TemporaryOutputFormat[_]])
-    TemporaryOutputFormat.setOutputPath(
+    job.setOutputFormatClass(classOf[TemporaryFileOutputFormat[_]])
+    FileOutputFormat.setOutputPath(
       job,
       new Path(path.getPath, s"${MockJobflowProcessorContext.EXTERNAL_INPUT_BASE}${name}"))
   }
@@ -140,12 +132,12 @@ class IterativeJobCompilerSpecBase(threshold: Option[Int], parallelism: Option[I
 
   def readResult[T: ClassTag](name: String, round: Int, path: File): RDD[T] = {
     val job = MRJob.getInstance(sc.hadoopConfiguration)
-    TemporaryInputFormat.setInputPaths(
+    FileInputFormat.setInputPaths(
       job,
-      Seq(new Path(path.getPath, s"${name}/round_${round}/part-*")))
+      new Path(path.getPath, s"${name}/round_${round}/part-*"))
     sc.newAPIHadoopRDD(
       job.getConfiguration,
-      classOf[TemporaryInputFormat[T]],
+      classOf[TemporaryFileInputFormat[T]],
       classOf[NullWritable],
       classTag[T].runtimeClass.asInstanceOf[Class[T]]).map(_._2)
   }

--- a/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/OutputClassBuilderSpec.scala
+++ b/extensions/iterativebatch/compiler/core/src/test/scala/com/asakusafw/spark/extensions/iterativebatch/compiler/graph/OutputClassBuilderSpec.scala
@@ -19,19 +19,18 @@ package graph
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-
 import java.io.{ DataInput, DataOutput, File }
+
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileInputFormat
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
 import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
-
 import com.asakusafw.bridge.stage.StageInfo
 import com.asakusafw.lang.compiler.api.CompilerOptions
 import com.asakusafw.lang.compiler.api.testing.MockJobflowProcessorContext
@@ -39,22 +38,14 @@ import com.asakusafw.lang.compiler.model.description.ClassDescription
 import com.asakusafw.lang.compiler.model.graph.{ ExternalOutput, MarkerOperator }
 import com.asakusafw.lang.compiler.planning.{ PlanBuilder, PlanMarker }
 import com.asakusafw.runtime.model.DataModel
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.compiler.{ ClassServerForAll, FlowIdForEach }
 import com.asakusafw.spark.compiler.graph._
 import com.asakusafw.spark.compiler.planning.SubPlanInfo
 import com.asakusafw.spark.runtime._
 import com.asakusafw.spark.runtime.JobContext.OutputCounter.External
-import com.asakusafw.spark.runtime.graph.{
-  Broadcast,
-  BroadcastId,
-  ParallelCollectionSource,
-  Source,
-  TemporaryOutput
-}
+import com.asakusafw.spark.runtime.graph.{ Broadcast, BroadcastId, ParallelCollectionSource, Source, TemporaryOutput }
 import com.asakusafw.spark.runtime.rdd.BranchKey
-
 import com.asakusafw.spark.extensions.iterativebatch.compiler.spi.RoundAwareNodeCompiler
 import com.asakusafw.spark.extensions.iterativebatch.runtime.graph.RoundAwareParallelCollectionSource
 
@@ -72,7 +63,7 @@ abstract class OutputClassBuilderSpec extends FlatSpec with ClassServerForAll wi
 
     sc.newAPIHadoopRDD(
       job.getConfiguration,
-      classOf[TemporaryInputFormat[Foo]],
+      classOf[TemporaryFileInputFormat[Foo]],
       classOf[NullWritable],
       classOf[Foo]).map(_._2.id.get).collect.toSeq.sorted
   }

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
     <java.version>1.8</java.version>
     <scala.compat.version>2.11</scala.compat.version>
     <scala.version>${scala.compat.version}.8</scala.version>
-    <spark.version>2.1.0</spark.version>
+    <spark.version>2.2.0</spark.version>
     <jetty.version>9.2.16.v20160414</jetty.version>
     <hadoop.version>2.7.3</hadoop.version>
-    <asm.version>5.0.3</asm.version>
+    <asm.version>5.2</asm.version>
     <scala-arm.version>1.4</scala-arm.version>
     <guava.version>14.0.1</guava.version>
 

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryInput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryInput.scala
@@ -16,24 +16,23 @@
 package com.asakusafw.spark.runtime
 package graph
 
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileInputFormat
+
 import scala.concurrent.Future
 import scala.reflect.ClassTag
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.rdd.RDD
-
 import com.asakusafw.bridge.stage.StageInfo
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.spark.runtime.JobContext.InputCounter
 import com.asakusafw.spark.runtime.rdd.BranchKey
 
 abstract class TemporaryInput[V: ClassTag](
   @transient val broadcasts: Map[BroadcastId, Broadcast[_]])(
     implicit jobContext: JobContext)
-  extends NewHadoopInput[TemporaryInputFormat[V], NullWritable, V] {
+  extends NewHadoopInput[TemporaryFileInputFormat[V], NullWritable, V] {
   self: CacheStrategy[RoundContext, Map[BranchKey, Future[() => RDD[_]]]] =>
 
   override def counter: InputCounter = InputCounter.External

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryOutput.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/graph/TemporaryOutput.scala
@@ -16,16 +16,16 @@
 package com.asakusafw.spark.runtime
 package graph
 
-import scala.reflect.{ classTag, ClassTag }
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileOutputFormat
 
+import scala.reflect.{ classTag, ClassTag }
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapreduce.{ Job => MRJob }
-
 import com.asakusafw.bridge.stage.StageInfo
-import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.spark.runtime.JobContext.OutputCounter
 import com.asakusafw.spark.runtime.rdd.BranchKey
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 
 abstract class TemporaryOutput[T: ClassTag](
   prevs: Seq[(Source, BranchKey)])(
@@ -40,10 +40,10 @@ abstract class TemporaryOutput[T: ClassTag](
     val job = MRJob.getInstance(rc.hadoopConf.value)
     job.setOutputKeyClass(classOf[NullWritable])
     job.setOutputValueClass(classTag[T].runtimeClass.asInstanceOf[Class[T]])
-    job.setOutputFormatClass(classOf[TemporaryOutputFormat[T]])
+    job.setOutputFormatClass(classOf[TemporaryFileOutputFormat[T]])
 
     val stageInfo = StageInfo.deserialize(job.getConfiguration.get(StageInfo.KEY_NAME))
-    TemporaryOutputFormat.setOutputPath(
+    FileOutputFormat.setOutputPath(
       job,
       new Path(stageInfo.resolveUserVariables(
         s"${path}/${Option(stageInfo.getStageId).getOrElse("-")}")))

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/InputSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/InputSpec.scala
@@ -19,14 +19,12 @@ package graph
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-
 import java.io.{ DataInput, DataOutput, File }
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.reflect.{ classTag, ClassTag }
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
@@ -36,12 +34,10 @@ import org.apache.hadoop.mapreduce.lib.output.{ FileOutputFormat, SequenceFileOu
 import org.apache.spark.{ Partitioner, SparkConf }
 import org.apache.spark.broadcast.{ Broadcast => Broadcasted }
 import org.apache.spark.rdd.RDD
-
 import com.asakusafw.bridge.hadoop.directio.DirectFileInputFormat
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileOutputFormat
 import com.asakusafw.runtime.directio.hadoop.{ HadoopDataSource, SequenceFileFormat }
 import com.asakusafw.runtime.model.DataModel
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
-import com.asakusafw.runtime.stage.output.TemporaryOutputFormat
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.runtime.JobContext.InputCounter
 import com.asakusafw.spark.runtime.TempDirForEach
@@ -80,8 +76,8 @@ class TemporaryInputSpec
   behavior of classOf[TemporaryInput[_]].getSimpleName
 
   val configurePath: (MRJob, String) => Unit = { (job, path) =>
-    job.setOutputFormatClass(classOf[TemporaryOutputFormat[Foo]])
-    TemporaryOutputFormat.setOutputPath(job, new Path(path))
+    job.setOutputFormatClass(classOf[TemporaryFileOutputFormat[Foo]])
+    FileOutputFormat.setOutputPath(job, new Path(path))
   }
 
   for {

--- a/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/OutputSpec.scala
+++ b/runtime/src/test/scala/com/asakusafw/spark/runtime/graph/OutputSpec.scala
@@ -19,24 +19,22 @@ package graph
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-
 import java.io.{ DataInput, DataOutput, File }
+
+import com.asakusafw.bridge.hadoop.temporary.TemporaryFileInputFormat
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ NullWritable, Writable }
 import org.apache.hadoop.mapreduce.{ Job => MRJob }
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.SparkConf
-
 import com.asakusafw.bridge.stage.StageInfo
 import com.asakusafw.runtime.model.DataModel
 import com.asakusafw.runtime.stage.StageConstants.EXPR_EXECUTION_ID
-import com.asakusafw.runtime.stage.input.TemporaryInputFormat
 import com.asakusafw.runtime.value.IntOption
 import com.asakusafw.spark.runtime.JobContext.OutputCounter.External
 import com.asakusafw.spark.runtime.TempDirForEach
@@ -54,7 +52,7 @@ abstract class OutputSpec extends FlatSpec with SparkForAll {
 
     sc.newAPIHadoopRDD(
       job.getConfiguration,
-      classOf[TemporaryInputFormat[Foo]],
+      classOf[TemporaryFileInputFormat[Foo]],
       classOf[NullWritable],
       classOf[Foo]).map(_._2.id.get).collect.toSeq.sorted
   }


### PR DESCRIPTION
## Summary

This PR bumps Apache Spark version `{2.1.0=>2.2.0}`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

We replaced use of `Temporary{Input,Output}Format` with `TemporaryFile{Input,Output}Format` for Spark 2.2.0 (see asakusafw/asakusafw-compiler#164).

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#164