### PR TITLE
Never `System.exit` in launcher.

### DIFF
--- a/bootstrap/src/main/java/com/asakusafw/spark/bootstrap/SparkBootstrap.java
+++ b/bootstrap/src/main/java/com/asakusafw/spark/bootstrap/SparkBootstrap.java
@@ -56,7 +56,9 @@ public class SparkBootstrap {
         SparkBootstrap bootstrap = new SparkBootstrap(Environment.system());
         int exitValue = bootstrap.exec(Context.parse(args));
         if (exitValue != 0) {
-            System.exit(exitValue);
+            throw new RuntimeException(MessageFormat.format(
+                    "Spark execution returned non-zero value: {0}",
+                    exitValue));
         }
     }
 

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/Launcher.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/Launcher.scala
@@ -57,7 +57,9 @@ object Launcher {
       }
 
       if (!RuntimeContext.get.isSimulation) {
-        sys.exit(sparkClient.execute(sparkConf, conf.getStageInfo))
+        val status = sparkClient.execute(sparkConf, conf.getStageInfo)
+        if (status != 0)
+          throw new RuntimeException(s"Spark execution returned non-zero value: ${status}")
       }
     } catch {
       case t: Throwable =>

--- a/runtime/src/main/scala/com/asakusafw/spark/runtime/Launcher.scala
+++ b/runtime/src/main/scala/com/asakusafw/spark/runtime/Launcher.scala
@@ -58,8 +58,9 @@ object Launcher {
 
       if (!RuntimeContext.get.isSimulation) {
         val status = sparkClient.execute(sparkConf, conf.getStageInfo)
-        if (status != 0)
+        if (status != 0) {
           throw new RuntimeException(s"Spark execution returned non-zero value: ${status}")
+        }
       }
     } catch {
       case t: Throwable =>


### PR DESCRIPTION
## Summary

This PR remove use of `{System, sys}.exit()` from Asakusa on Spark client.

## Background, Problem or Goal of the patch

Using Spark >= 2.0 and YARN, Spark application should not use `sys.exit()` to keep YARN AppMaster alive. 

## Design of the fix, or a new feature

This PR replaced `sys.exit` with throwing exception if Spark execution was failed, or just return the main method.

## Related Issue, Pull Request or Code

N/A.