### PR TITLE
Fix javaRuntimeName of eclipse.jdt

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -70,7 +70,7 @@ tasks.withType(AbstractCompile) { task ->
 }
 
 eclipse.jdt {
-    javaRuntimeName = 'JavaSE-1.7'
+    javaRuntimeName = "JavaSE-${sourceCompatibility}"
 }
 if (project.hasProperty('referProject')) {
     eclipse.classpath.file.whenMerged { classpath ->


### PR DESCRIPTION
## Summary
This PR fixes `eclipse.jdt.javaRuntimeName` of Gradle Plugin project config.

## Background, Problem or Goal of the patch
This makes the same definition as other asakusafw-* projects.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
