### PR TITLE
Fix to fail Direct I/O output filename in random value

### DIFF
--- a/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectOutputPrepareClassBuilder.scala
+++ b/compiler/src/main/scala/com/asakusafw/spark/compiler/graph/DirectOutputPrepareClassBuilder.scala
@@ -278,7 +278,7 @@ abstract class DirectOutputPrepareGroupClassBuilder(
                   pushNew(OutputPatternGeneratorClassBuilder.getOrCompile(dataModelRef))
                 generator.dup().invokeInit(
                   buildSeq { builder =>
-                    var randoms = 0
+                    var randoms = 0L
                     pattern.getResourcePattern.foreach { segment =>
                       segment.getKind match {
                         case OutputPattern.SourceKind.NOTHING =>


### PR DESCRIPTION
## Summary
This PR fixes to fail when Direct I/O output filename pattern includes random value ( e.g. `[0..9]` ). 

## Background, Problem or Goal of the patch
Direct I/O output stage fails wgeb Direct I/O output filename pattern includes random value as following error logs: 
```
java.lang.NoSuchMethodError:
com.asakusafw.spark.runtime.directio.OutputPatternGenerator$.random(III)Lcom/asakusafw/spark/runtime/directio/OutputPatternGenerator$Fragment;
...
```

## Design of the fix, or a new feature
Modified to correct method syntax in `DirectOutputPrepareFlatClassBuilder`

## Related Issue, Pull Request or Code
N/A.