### PR TITLE
add integration test cases for Direct I/O Hive with Asakusa on Spark.

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -24,7 +24,7 @@ This integration test requires both development and runtime environment of Asaku
 ### Available options
 
 * `-PmavenLocal`
-  * use artifacts of *test tools* on local repository, this also refers artifacts of `asakusa-core-integration`
+  * use artifacts of *test tools* on local repository, this also refers artifacts of `asakusa-core-integration` and `asakusa-lang-integration`
   * default: never use artifacts on local repository
 * `-Dmaven.local=false`
   * use artifacts of *testee* only on remote repositories

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -28,6 +28,7 @@ def versions = { f ->
     def props = xml['properties']
     return [
         'asakusafw' : props['asakusafw.version'],
+        'asakusafw-lang' : props['asakusafw-lang.version'],
         'asakusafw-spark' : xml.version.text(),
     ]
 }(project.file('../pom.xml'))
@@ -59,6 +60,7 @@ dependencies {
     runtime 'org.slf4j:slf4j-simple:1.7.25'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     integrationTestData "com.asakusafw.integration:asakusa-core-integration:${versions['asakusafw']}:integration-test-data@zip"
+    integrationTestData "com.asakusafw.integration:asakusa-lang-integration:${versions['asakusafw-lang']}:integration-test-data@zip"
     deployerJars 'org.springframework.build:aws-maven:5.0.0.RELEASE'
 }
 

--- a/integration/src/integration-test/data/spark/build.gradle
+++ b/integration/src/integration-test/data/spark/build.gradle
@@ -55,3 +55,17 @@ test {
         exceptionFormat 'full'
     }
 }
+
+if (System.getProperty('hive.version')) {
+    asakusafw {
+        sdk.hive true
+    }
+    asakusafwOrganizer {
+        hive.enabled true
+    }
+    if (System.getProperty('hive.version', 'default') != 'default') {
+        asakusafwOrganizer {
+            hive.libraries = ["org.apache.hive:hive-exec:${System.getProperty('hive.version')}"]
+        }
+    }
+}

--- a/integration/src/integration-test/java/com/asakusafw/integration/spark/HiveTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/spark/HiveTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.integration.spark;
+
+import static com.asakusafw.integration.spark.Util.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.asakusafw.integration.AsakusaConfigurator;
+import com.asakusafw.integration.AsakusaConstants;
+import com.asakusafw.integration.AsakusaProject;
+import com.asakusafw.integration.AsakusaProjectProvider;
+import com.asakusafw.utils.gradle.ContentsConfigurator;
+import com.asakusafw.utils.gradle.PropertyConfigurator;
+
+/**
+ * Test for Direct I/O Hive.
+ */
+@RunWith(Parameterized.class)
+public class HiveTest {
+
+    /**
+     * Return the test parameters.
+     * @return the test parameters
+     */
+    @Parameters(name = "{0}")
+    public static Object[][] getTestParameters() {
+        return new Object[][] {
+            { "default", },
+            {   "1.1.1", },
+            {   "1.2.1", },
+            {   "1.2.2", },
+            {   "2.3.4", },
+        };
+    }
+
+     /**
+     * project provider.
+     */
+    @Rule
+    public final AsakusaProjectProvider provider = new AsakusaProjectProvider()
+            .withProject(ContentsConfigurator.copy(data("spark")))
+            .withProject(ContentsConfigurator.copy(data("ksv-hive")))
+            .withProject(ContentsConfigurator.copy(data("logback-test")))
+            .withProject(AsakusaConfigurator.projectHome())
+            .withProject(AsakusaConfigurator.hadoop(AsakusaConfigurator.Action.UNSET_IF_UNDEFINED))
+            .withProject(AsakusaConfigurator.spark(AsakusaConfigurator.Action.SKIP_IF_UNDEFINED));
+
+    /**
+     * creates a new instance.
+     * @param hiveVersion the hive-exec version
+     */
+    public HiveTest(String hiveVersion) {
+        provider.withProject(PropertyConfigurator.of("hive.version", String.valueOf(hiveVersion)));
+    }
+
+    /**
+     * {@code run}.
+     */
+    @Test
+    public void run_orc() {
+        AsakusaProject project = provider.newInstance("prj");
+        project.gradle("attachSparkBatchapps", "installAsakusafw");
+
+        String[] csv = new String[] {
+                "1,1.0,A",
+                "2,2.0,B",
+                "3,3.0,C",
+        };
+        project.getContents().put("var/data/input/file.csv", f -> {
+            Files.write(f, Arrays.asList(csv), StandardCharsets.UTF_8);
+        });
+
+        project.getFramework().withLaunch(
+                AsakusaConstants.CMD_PORTAL, "run", "spark.perf.orc.io",
+                "-Acsv.input=input", "-Acsv.output=output",
+                "-Ainput=tmp", "-Aoutput=tmp");
+
+        project.getContents().get("var/data/output", dir -> {
+            List<String> results = Files.list(dir)
+                .flatMap(Util::lines)
+                .sorted()
+                .map(this::normalize)
+                .collect(Collectors.toList());
+            assertThat(results, containsInAnyOrder(csv));
+        });
+    }
+
+    /**
+     * {@code run}.
+     */
+    @Test
+    public void run_parquet() {
+        AsakusaProject project = provider.newInstance("prj");
+        project.gradle("attachSparkBatchapps", "installAsakusafw");
+
+        String[] csv = new String[] {
+                "1,1.0,A",
+                "2,2.0,B",
+                "3,3.0,C",
+        };
+        project.getContents().put("var/data/input/file.csv", f -> {
+            Files.write(f, Arrays.asList(csv), StandardCharsets.UTF_8);
+        });
+
+        project.getFramework().withLaunch(
+                AsakusaConstants.CMD_PORTAL, "run", "spark.perf.parquet.io",
+                "-Acsv.input=input", "-Acsv.output=output",
+                "-Ainput=tmp", "-Aoutput=tmp");
+
+        project.getContents().get("var/data/output", dir -> {
+            List<String> results = Files.list(dir)
+                .flatMap(Util::lines)
+                .sorted()
+                .map(this::normalize)
+                .collect(Collectors.toList());
+            assertThat(results, containsInAnyOrder(csv));
+        });
+    }
+
+    private String normalize(String line) {
+        String[] segments = line.split(",");
+        assertThat(segments.length, is(3));
+        return String.format("%d,%s,%s",
+                Integer.parseInt(segments[0]),
+                new BigDecimal(segments[1]).setScale(1).toPlainString(),
+                segments[2]);
+    }
+}

--- a/integration/src/integration-test/java/com/asakusafw/integration/spark/PortalTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/spark/PortalTest.java
@@ -25,6 +25,7 @@ import com.asakusafw.integration.AsakusaConstants;
 import com.asakusafw.integration.AsakusaProjectProvider;
 import com.asakusafw.utils.gradle.Bundle;
 import com.asakusafw.utils.gradle.ContentsConfigurator;
+import com.asakusafw.utils.gradle.PropertyConfigurator;
 
 /**
  * Test for the portal command.
@@ -39,6 +40,7 @@ public class PortalTest {
             .withProject(ContentsConfigurator.copy(data("spark")))
             .withProject(ContentsConfigurator.copy(data("ksv")))
             .withProject(ContentsConfigurator.copy(data("logback-test")))
+            .withProject(PropertyConfigurator.of("hive.version", (String) null))
             .withProject(AsakusaConfigurator.projectHome())
             .withProject(AsakusaConfigurator.hadoop(AsakusaConfigurator.Action.UNSET_ALWAYS))
             .withProvider(provider -> {

--- a/integration/src/integration-test/java/com/asakusafw/integration/spark/SparkTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/spark/SparkTest.java
@@ -35,6 +35,7 @@ import com.asakusafw.integration.AsakusaProject;
 import com.asakusafw.integration.AsakusaProjectProvider;
 import com.asakusafw.utils.gradle.Bundle;
 import com.asakusafw.utils.gradle.ContentsConfigurator;
+import com.asakusafw.utils.gradle.PropertyConfigurator;
 
 /**
  * Test for {@code spark}.
@@ -49,6 +50,7 @@ public class SparkTest {
             .withProject(ContentsConfigurator.copy(data("spark")))
             .withProject(ContentsConfigurator.copy(data("ksv")))
             .withProject(ContentsConfigurator.copy(data("logback-test")))
+            .withProject(PropertyConfigurator.of("hive.version", (String) null))
             .withProject(AsakusaConfigurator.projectHome())
             .withProject(AsakusaConfigurator.hadoop(AsakusaConfigurator.Action.UNSET_IF_UNDEFINED))
             .withProject(AsakusaConfigurator.spark(AsakusaConfigurator.Action.SKIP_IF_UNDEFINED));


### PR DESCRIPTION
## Summary

This PR adds integration test cases for Direct I/O Hive with Asakusa on Spark.

## Background, Problem or Goal of the patch

This is integration tests of asakusafw/asakusafw#838.

## Design of the fix, or a new feature

Spark 2.3.3 with bundled Hadoop 2.7 already includes `hive-exec 1.2.1` internally, with the result that the Asakusa on Spark always activates `hive-exec 1.2.1` even if developers put a newer version of `hive-exec` into `ext/lib`.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#838
* asakusafw/asakusafw-compiler#198
