### PR TITLE
Change maven repository URL to use https in build configurations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Bug reports, Patch contribution
 * Please report any issues to [repository for issue tracking](https://github.com/asakusafw/asakusafw-issues/issues)
-* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](http://docs.asakusafw.com/latest/release/ja/html/contribution.html)
+* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](https://docs.asakusafw.com/latest/release/ja/html/contribution.html)
 
 ## Template of Issues or Pull Requests
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ dependency-reduced-pom.xml
 .idea
 *.iml
 
+# Visual Studio Code
+.vscode

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd gradle
 * [Asakusa Framework Documentation](https://github.com/asakusafw/asakusafw-documentation)
 
 ## Resources
-* [Asakusa on Spark Documentation (ja)](http://docs.asakusafw.com/asakusa-on-spark/)
+* [Asakusa on Spark Documentation (ja)](https://docs.asakusafw.com/asakusa-on-spark/)
 
 ## License
 * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -47,8 +47,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
 }
 
 dependencies {

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -49,8 +49,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 

--- a/integration/src/integration-test/data/spark/build.gradle
+++ b/integration/src/integration-test/data/spark/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.spark', 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <version>0.5.4-SNAPSHOT</version>
 
   <description>Asakusa DSL Compiler for Spark Project Root</description>
-  <url>http://asakusafw.com</url>
+  <url>https://asakusafw.com</url>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -21,7 +21,7 @@
   <inceptionYear>2011</inceptionYear>
   <organization>
     <name>Asakusa Framework Team</name>
-    <url>http://asakusafw.com</url>
+    <url>https://asakusafw.com</url>
   </organization>
 
   <scm>
@@ -800,7 +800,7 @@ encoding/<project>=UTF-8
   <repositories>
     <repository>
       <id>com.asakusafw.releases</id>
-      <url>http://asakusafw.s3.amazonaws.com/maven/releases</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/releases</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -811,7 +811,7 @@ encoding/<project>=UTF-8
     <repository>
       <id>com.asakusafw.snapshots</id>
       <name>Asakusa Framework Snapshot Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/snapshots</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -838,7 +838,7 @@ encoding/<project>=UTF-8
     <pluginRepository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>
@@ -850,7 +850,7 @@ encoding/<project>=UTF-8
     <pluginRepository>
       <id>com.asakusafw.releases</id>
       <name>Asakusa Framework Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/releases</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -858,7 +858,7 @@ encoding/<project>=UTF-8
     <pluginRepository>
       <id>com.asakusafw.snapshots</id>
       <name>Asakusa Framework Snapshot Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/snapshots</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
## Summary
This PR changes maven repository URL protocol from http to https in `pom.xml` and `build.gradle` for framework build configurations.
This also changes link URL to https in documentation files.

## Background, Problem or Goal of the patch
Follow-up asakusafw/asakusafw#845

## Design of the fix, or a new feature
The same as asakusafw/asakusafw#845

## Related Issue, Pull Request or Code
N/A.
